### PR TITLE
feat: GitHub Sponsors funding + five more bundled schemas

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: Soutar97

--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ Deliberately out of scope to keep it small and sharp: interactive/TUI programs (
 subcommand trees (flat tools only — `git commit` vs `git push` is v0.2); native file-picker dialogs;
 a hosted version, auth, telemetry, or a plugin system.
 
+## Support
+
+If instagui saves you time, you can sponsor development on [GitHub](https://github.com/sponsors/Soutar97).
+Starring the repo and contributing schemas helps just as much.
+
 ## License
 
 MIT © Omar

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ As featured in [The Register](https://www.theregister.com/software/2026/07/07/ne
 
 Turn any command-line tool into a clean local web form — no config, no code changes to the tool.
 
-<!-- TODO(pre-launch): record and drop the money-demo GIF here.
-     ~10s: `npx instagui ffmpeg` → browser opens → fill a couple fields → Run → output streams.
-     Save as docs/demo.gif and it renders below. -->
 ![instagui demo — npx instagui ffmpeg opens a web form, click Run, output streams](docs/demo.gif)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ parses the tool's own `--help` text with AI into a structured schema and renders
 
 ## Quick start
 
-The three demo tools ship with **bundled schemas**, so they work instantly with **no API key**:
+The demo tools ship with **bundled schemas**, so they work instantly with **no API key**:
 
 ```sh
 npx instagui ffmpeg      # video/audio transcoding
@@ -38,13 +38,14 @@ npx instagui yt-dlp      # download media
 npx instagui pandoc      # convert documents
 ```
 
-For any *other* tool, instagui extracts the schema on first run using the Claude API (see
+More common tools are bundled too — `curl`, `jq`, `tar`, `magick`, and `zip` — and are just as
+keyless. For any *other* tool, instagui extracts the schema on first run using the Claude API (see
 [How it stays free](#how-it-stays-free)):
 
 ```sh
 export ANTHROPIC_API_KEY=sk-ant-...    # POSIX
 $env:ANTHROPIC_API_KEY="sk-ant-..."    # Windows / PowerShell
-npx instagui curl
+npx instagui wget
 ```
 
 Get a key at <https://console.anthropic.com>. The first extraction is cached, so every launch
@@ -92,8 +93,8 @@ So instagui never asks you to put a key in a file — you set the relevant **env
 Pick one explicitly with `--engine <name>`:
 
 ```sh
-npx instagui curl --engine claude    # use the claude CLI (no API key needed, just `claude` login)
-npx instagui curl --engine openai    # use the OpenAI API (needs OPENAI_API_KEY)
+npx instagui wget --engine claude    # use the claude CLI (no API key needed, just `claude` login)
+npx instagui wget --engine openai    # use the OpenAI API (needs OPENAI_API_KEY)
 ```
 
 Built-in engine names, no config required:
@@ -130,8 +131,8 @@ model, or set a `default` engine, create `~/.instagui/config.json`:
 **environment variable** that holds the key — instagui never reads a raw key from disk, and a
 config that puts a plaintext `key` in the file is rejected with an error pointing you back to `keyEnv`.
 
-None of this applies to the bundled demo tools: `ffmpeg`, `yt-dlp`, and `pandoc` resolve from
-shipped schemas and need **no engine at all**, ready or not.
+None of this applies to the bundled tools (`ffmpeg`, `yt-dlp`, `pandoc`, `curl`, `jq`, `tar`,
+`magick`, `zip`): they resolve from shipped schemas and need **no engine at all**, ready or not.
 
 ## How it works
 
@@ -154,7 +155,7 @@ instagui resolves a schema in this order, and only the last step costs an API ca
 | --- | --- | --- |
 | 1 | `--schema <file>` override you supply | no |
 | 2 | Your cache in `~/.instagui/` (written on first extraction) | no |
-| 3 | Bundled schemas shipped with the package (ffmpeg, yt-dlp, pandoc) | no |
+| 3 | Bundled schemas shipped with the package (ffmpeg, yt-dlp, pandoc, curl, jq, tar, magick, zip) | no |
 | 4 | Fresh extraction via your selected AI engine | **yes** (a key or a logged-in CLI — see [Choosing an AI engine](#choosing-an-ai-engine)) |
 
 So the demo tools are free forever, any tool you've used once is free forever after, and you only

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -5,7 +5,11 @@ These are the read-only fallback schemas that let the demo tools work with **no 
 → **these bundled schemas** → fresh extraction. The user cache always wins; these files are
 never overwritten at runtime.
 
-Currently bundled: `ffmpeg`, `yt-dlp`, `pandoc`.
+Currently bundled: `ffmpeg`, `yt-dlp`, `pandoc`, `curl`, `jq`, `tar`, `magick`, `zip`.
+
+> `rsync` was requested for bundling too but is intentionally **not** shipped: there is no clean
+> binary available to capture an authentic `--help` fixture from on the generation platform, and a
+> bundled schema is only as honest as the fixture it was verified against. Skipped, never guessed.
 
 ## Provenance
 

--- a/schemas/curl.json
+++ b/schemas/curl.json
@@ -1,0 +1,2485 @@
+{
+  "tool": "curl",
+  "summary": "",
+  "options": [
+    {
+      "name": "abstract-unix-socket",
+      "flag": "--abstract-unix-socket <path>",
+      "type": "path",
+      "description": "Connect via abstract Unix domain socket",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "alt-svc",
+      "flag": "--alt-svc <filename>",
+      "type": "path",
+      "description": "Enable alt-svc with this cache file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "anyauth",
+      "flag": "--anyauth",
+      "type": "boolean",
+      "description": "Pick any authentication method",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "append",
+      "flag": "-a, --append",
+      "type": "boolean",
+      "description": "Append to target file when uploading",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "aws-sigv4",
+      "flag": "--aws-sigv4 <provider1[:prvdr2[:reg[:srv]]]>",
+      "type": "string",
+      "description": "AWS V4 signature auth",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "basic",
+      "flag": "--basic",
+      "type": "boolean",
+      "description": "HTTP Basic Authentication",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ca-native",
+      "flag": "--ca-native",
+      "type": "boolean",
+      "description": "Load CA certs from the OS",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "cacert",
+      "flag": "--cacert <file>",
+      "type": "path",
+      "description": "CA certificate to verify peer against",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "capath",
+      "flag": "--capath <dir>",
+      "type": "path",
+      "description": "CA directory to verify peer against",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "cert",
+      "flag": "-E, --cert <certificate[:password]>",
+      "type": "string",
+      "description": "Client certificate file and password",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "cert-status",
+      "flag": "--cert-status",
+      "type": "boolean",
+      "description": "Verify server cert status OCSP-staple",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "cert-type",
+      "flag": "--cert-type <type>",
+      "type": "enum",
+      "description": "Certificate type (DER/PEM/ENG/PROV/P12)",
+      "enumValues": [
+        "DER",
+        "PEM",
+        "ENG",
+        "PROV",
+        "P12"
+      ],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ciphers",
+      "flag": "--ciphers <list>",
+      "type": "string",
+      "description": "TLS 1.2 (1.1, 1.0) ciphers to use",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "compressed",
+      "flag": "--compressed",
+      "type": "boolean",
+      "description": "Request compressed response",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "compressed-ssh",
+      "flag": "--compressed-ssh",
+      "type": "boolean",
+      "description": "Enable SSH compression",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "config",
+      "flag": "-K, --config <file>",
+      "type": "path",
+      "description": "Read config from a file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "connect-timeout",
+      "flag": "--connect-timeout <seconds>",
+      "type": "number",
+      "description": "Maximum time allowed to connect",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "connect-to",
+      "flag": "--connect-to <HOST1:PORT1:HOST2:PORT2>",
+      "type": "string",
+      "description": "Connect to host2 instead of host1",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "continue-at",
+      "flag": "-C, --continue-at <offset>",
+      "type": "string",
+      "description": "Resumed transfer offset",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "cookie",
+      "flag": "-b, --cookie <data|filename>",
+      "type": "string",
+      "description": "Send cookies from string/load from file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "cookie-jar",
+      "flag": "-c, --cookie-jar <filename>",
+      "type": "path",
+      "description": "Save cookies to filename after operation",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "create-dirs",
+      "flag": "--create-dirs",
+      "type": "boolean",
+      "description": "Create necessary local directory hierarchy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "create-file-mode",
+      "flag": "--create-file-mode <mode>",
+      "type": "string",
+      "description": "File mode for created files",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "crlf",
+      "flag": "--crlf",
+      "type": "boolean",
+      "description": "Convert LF to CRLF in upload",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "crlfile",
+      "flag": "--crlfile <file>",
+      "type": "path",
+      "description": "Certificate Revocation list",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "curves",
+      "flag": "--curves <list>",
+      "type": "string",
+      "description": "(EC) TLS key exchange algorithms to request",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "data",
+      "flag": "-d, --data <data>",
+      "type": "string",
+      "description": "HTTP POST data",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "data-ascii",
+      "flag": "--data-ascii <data>",
+      "type": "string",
+      "description": "HTTP POST ASCII data",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "data-binary",
+      "flag": "--data-binary <data>",
+      "type": "string",
+      "description": "HTTP POST binary data",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "data-raw",
+      "flag": "--data-raw <data>",
+      "type": "string",
+      "description": "HTTP POST data, '@' allowed",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "data-urlencode",
+      "flag": "--data-urlencode <data>",
+      "type": "string",
+      "description": "HTTP POST data URL encoded",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "delegation",
+      "flag": "--delegation <LEVEL>",
+      "type": "string",
+      "description": "GSS-API delegation permission",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "digest",
+      "flag": "--digest",
+      "type": "boolean",
+      "description": "HTTP Digest Authentication",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "disable",
+      "flag": "-q, --disable",
+      "type": "boolean",
+      "description": "Disable .curlrc",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "disable-eprt",
+      "flag": "--disable-eprt",
+      "type": "boolean",
+      "description": "Inhibit using EPRT or LPRT",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "disable-epsv",
+      "flag": "--disable-epsv",
+      "type": "boolean",
+      "description": "Inhibit using EPSV",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "disallow-username-in-url",
+      "flag": "--disallow-username-in-url",
+      "type": "boolean",
+      "description": "Disallow username in URL",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "dns-interface",
+      "flag": "--dns-interface <interface>",
+      "type": "string",
+      "description": "Interface to use for DNS requests",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "dns-ipv4-addr",
+      "flag": "--dns-ipv4-addr <address>",
+      "type": "string",
+      "description": "IPv4 address to use for DNS requests",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "dns-ipv6-addr",
+      "flag": "--dns-ipv6-addr <address>",
+      "type": "string",
+      "description": "IPv6 address to use for DNS requests",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "dns-servers",
+      "flag": "--dns-servers <addresses>",
+      "type": "string",
+      "description": "DNS server addrs to use",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "doh-cert-status",
+      "flag": "--doh-cert-status",
+      "type": "boolean",
+      "description": "Verify DoH server cert status OCSP-staple",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "doh-insecure",
+      "flag": "--doh-insecure",
+      "type": "boolean",
+      "description": "Allow insecure DoH server connections",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "doh-url",
+      "flag": "--doh-url <URL>",
+      "type": "string",
+      "description": "Resolve hostnames over DoH",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "dump-ca-embed",
+      "flag": "--dump-ca-embed",
+      "type": "boolean",
+      "description": "Write the embedded CA bundle to standard output",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "dump-header",
+      "flag": "-D, --dump-header <filename>",
+      "type": "path",
+      "description": "Write the received headers to filename",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ech",
+      "flag": "--ech <config>",
+      "type": "string",
+      "description": "Configure ECH",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "egd-file",
+      "flag": "--egd-file <file>",
+      "type": "path",
+      "description": "EGD socket path for random data",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "engine",
+      "flag": "--engine <name>",
+      "type": "string",
+      "description": "Crypto engine to use",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "etag-compare",
+      "flag": "--etag-compare <file>",
+      "type": "path",
+      "description": "Load ETag from file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "etag-save",
+      "flag": "--etag-save <file>",
+      "type": "path",
+      "description": "Parse incoming ETag and save to a file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "expect100-timeout",
+      "flag": "--expect100-timeout <seconds>",
+      "type": "number",
+      "description": "How long to wait for 100-continue",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "fail",
+      "flag": "-f, --fail",
+      "type": "boolean",
+      "description": "Fail fast with no output on HTTP errors",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "fail-early",
+      "flag": "--fail-early",
+      "type": "boolean",
+      "description": "Fail on first transfer error",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "fail-with-body",
+      "flag": "--fail-with-body",
+      "type": "boolean",
+      "description": "Fail on HTTP errors but save the body",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "false-start",
+      "flag": "--false-start",
+      "type": "boolean",
+      "description": "Enable TLS False Start",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "follow",
+      "flag": "--follow",
+      "type": "boolean",
+      "description": "Follow redirects per spec",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "form",
+      "flag": "-F, --form <name=content>",
+      "type": "string",
+      "description": "Specify multipart MIME data",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "form-escape",
+      "flag": "--form-escape",
+      "type": "boolean",
+      "description": "Escape form fields using backslash",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "form-string",
+      "flag": "--form-string <name=string>",
+      "type": "string",
+      "description": "Specify multipart MIME data",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-account",
+      "flag": "--ftp-account <data>",
+      "type": "string",
+      "description": "Account data string",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-alternative-to-user",
+      "flag": "--ftp-alternative-to-user <command>",
+      "type": "string",
+      "description": "String to replace USER [name]",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-create-dirs",
+      "flag": "--ftp-create-dirs",
+      "type": "boolean",
+      "description": "Create the remote dirs if not present",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-method",
+      "flag": "--ftp-method <method>",
+      "type": "string",
+      "description": "Control CWD usage",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-pasv",
+      "flag": "--ftp-pasv",
+      "type": "boolean",
+      "description": "Send PASV/EPSV instead of PORT",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-port",
+      "flag": "-P, --ftp-port <address>",
+      "type": "string",
+      "description": "Send PORT instead of PASV",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-pret",
+      "flag": "--ftp-pret",
+      "type": "boolean",
+      "description": "Send PRET before PASV",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-skip-pasv-ip",
+      "flag": "--ftp-skip-pasv-ip",
+      "type": "boolean",
+      "description": "Skip the IP address for PASV",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-ssl-ccc",
+      "flag": "--ftp-ssl-ccc",
+      "type": "boolean",
+      "description": "Send CCC after authenticating",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-ssl-ccc-mode",
+      "flag": "--ftp-ssl-ccc-mode <active/passive>",
+      "type": "enum",
+      "description": "Set CCC mode",
+      "enumValues": [
+        "active",
+        "passive"
+      ],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ftp-ssl-control",
+      "flag": "--ftp-ssl-control",
+      "type": "boolean",
+      "description": "Require TLS for login, clear for transfer",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "get",
+      "flag": "-G, --get",
+      "type": "boolean",
+      "description": "Put the post data in the URL and use GET",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "globoff",
+      "flag": "-g, --globoff",
+      "type": "boolean",
+      "description": "Disable URL globbing with {} and []",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "happy-eyeballs-timeout-ms",
+      "flag": "--happy-eyeballs-timeout-ms <ms>",
+      "type": "number",
+      "description": "Time for IPv6 before IPv4",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "haproxy-clientip",
+      "flag": "--haproxy-clientip <ip>",
+      "type": "string",
+      "description": "Set address in HAProxy PROXY",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "haproxy-protocol",
+      "flag": "--haproxy-protocol",
+      "type": "boolean",
+      "description": "Send HAProxy PROXY protocol v1 header",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "head",
+      "flag": "-I, --head",
+      "type": "boolean",
+      "description": "Show document info only",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "header",
+      "flag": "-H, --header <header/@file>",
+      "type": "string",
+      "description": "Pass custom header(s) to server",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "help",
+      "flag": "-h, --help <subject>",
+      "type": "string",
+      "description": "Get help for commands",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "hostpubmd5",
+      "flag": "--hostpubmd5 <md5>",
+      "type": "string",
+      "description": "Acceptable MD5 hash of host public key",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "hostpubsha256",
+      "flag": "--hostpubsha256 <sha256>",
+      "type": "string",
+      "description": "Acceptable SHA256 hash of host public key",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "hsts",
+      "flag": "--hsts <filename>",
+      "type": "path",
+      "description": "Enable HSTS with this cache file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "http0.9",
+      "flag": "--http0.9",
+      "type": "boolean",
+      "description": "Allow HTTP/0.9 responses",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "http1.0",
+      "flag": "-0, --http1.0",
+      "type": "boolean",
+      "description": "Use HTTP/1.0",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "http1.1",
+      "flag": "--http1.1",
+      "type": "boolean",
+      "description": "Use HTTP/1.1",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "http2",
+      "flag": "--http2",
+      "type": "boolean",
+      "description": "Use HTTP/2",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "http2-prior-knowledge",
+      "flag": "--http2-prior-knowledge",
+      "type": "boolean",
+      "description": "Use HTTP/2 without HTTP/1.1 Upgrade",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "http3",
+      "flag": "--http3",
+      "type": "boolean",
+      "description": "Use HTTP/3",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "http3-only",
+      "flag": "--http3-only",
+      "type": "boolean",
+      "description": "Use HTTP/3 only",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ignore-content-length",
+      "flag": "--ignore-content-length",
+      "type": "boolean",
+      "description": "Ignore the size of the remote resource",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "insecure",
+      "flag": "-k, --insecure",
+      "type": "boolean",
+      "description": "Allow insecure server connections",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "interface",
+      "flag": "--interface <name>",
+      "type": "string",
+      "description": "Use network interface",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ip-tos",
+      "flag": "--ip-tos <string>",
+      "type": "string",
+      "description": "Set IP Type of Service or Traffic Class",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ipfs-gateway",
+      "flag": "--ipfs-gateway <URL>",
+      "type": "string",
+      "description": "Gateway for IPFS",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ipv4",
+      "flag": "-4, --ipv4",
+      "type": "boolean",
+      "description": "Resolve names to IPv4 addresses",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ipv6",
+      "flag": "-6, --ipv6",
+      "type": "boolean",
+      "description": "Resolve names to IPv6 addresses",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "json",
+      "flag": "--json <data>",
+      "type": "string",
+      "description": "HTTP POST JSON",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "junk-session-cookies",
+      "flag": "-j, --junk-session-cookies",
+      "type": "boolean",
+      "description": "Ignore session cookies read from file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "keepalive-cnt",
+      "flag": "--keepalive-cnt <integer>",
+      "type": "number",
+      "description": "Maximum number of keepalive probes",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "keepalive-time",
+      "flag": "--keepalive-time <seconds>",
+      "type": "number",
+      "description": "Interval time for keepalive probes",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "key",
+      "flag": "--key <key>",
+      "type": "path",
+      "description": "Private key filename",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "key-type",
+      "flag": "--key-type <type>",
+      "type": "enum",
+      "description": "Private key file type (DER/PEM/ENG)",
+      "enumValues": [
+        "DER",
+        "PEM",
+        "ENG"
+      ],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "knownhosts",
+      "flag": "--knownhosts <file>",
+      "type": "path",
+      "description": "Specify knownhosts path",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "krb",
+      "flag": "--krb <level>",
+      "type": "string",
+      "description": "Enable Kerberos with security level",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "libcurl",
+      "flag": "--libcurl <file>",
+      "type": "path",
+      "description": "Generate libcurl code for this command line",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "limit-rate",
+      "flag": "--limit-rate <speed>",
+      "type": "string",
+      "description": "Limit transfer speed to RATE",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "list-only",
+      "flag": "-l, --list-only",
+      "type": "boolean",
+      "description": "List only mode",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "local-port",
+      "flag": "--local-port <range>",
+      "type": "string",
+      "description": "Use a local port number within RANGE",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "location",
+      "flag": "-L, --location",
+      "type": "boolean",
+      "description": "Follow redirects",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "location-trusted",
+      "flag": "--location-trusted",
+      "type": "boolean",
+      "description": "As --location, but send secrets to other hosts",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "login-options",
+      "flag": "--login-options <options>",
+      "type": "string",
+      "description": "Server login options",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "mail-auth",
+      "flag": "--mail-auth <address>",
+      "type": "string",
+      "description": "Originator address of the original email",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "mail-from",
+      "flag": "--mail-from <address>",
+      "type": "string",
+      "description": "Mail from this address",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "mail-rcpt",
+      "flag": "--mail-rcpt <address>",
+      "type": "string",
+      "description": "Mail to this address",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "mail-rcpt-allowfails",
+      "flag": "--mail-rcpt-allowfails",
+      "type": "boolean",
+      "description": "Allow RCPT TO command to fail",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "manual",
+      "flag": "-M, --manual",
+      "type": "boolean",
+      "description": "Display the full manual",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "max-filesize",
+      "flag": "--max-filesize <bytes>",
+      "type": "number",
+      "description": "Maximum file size to download",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "max-redirs",
+      "flag": "--max-redirs <num>",
+      "type": "number",
+      "description": "Maximum number of redirects allowed",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "max-time",
+      "flag": "-m, --max-time <seconds>",
+      "type": "number",
+      "description": "Maximum time allowed for transfer",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "metalink",
+      "flag": "--metalink",
+      "type": "boolean",
+      "description": "Process given URLs as metalink XML file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "mptcp",
+      "flag": "--mptcp",
+      "type": "boolean",
+      "description": "Enable Multipath TCP",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "negotiate",
+      "flag": "--negotiate",
+      "type": "boolean",
+      "description": "Use HTTP Negotiate (SPNEGO) authentication",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "netrc",
+      "flag": "-n, --netrc",
+      "type": "boolean",
+      "description": "Must read .netrc for username and password",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "netrc-file",
+      "flag": "--netrc-file <filename>",
+      "type": "path",
+      "description": "Specify FILE for netrc",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "netrc-optional",
+      "flag": "--netrc-optional",
+      "type": "boolean",
+      "description": "Use either .netrc or URL",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "next",
+      "flag": "-:, --next",
+      "type": "boolean",
+      "description": "Make next URL use separate options",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-alpn",
+      "flag": "--no-alpn",
+      "type": "boolean",
+      "description": "Disable the ALPN TLS extension",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-buffer",
+      "flag": "-N, --no-buffer",
+      "type": "boolean",
+      "description": "Disable buffering of the output stream",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-clobber",
+      "flag": "--no-clobber",
+      "type": "boolean",
+      "description": "Do not overwrite files that already exist",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-keepalive",
+      "flag": "--no-keepalive",
+      "type": "boolean",
+      "description": "Disable TCP keepalive on the connection",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-npn",
+      "flag": "--no-npn",
+      "type": "boolean",
+      "description": "Disable the NPN TLS extension",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-progress-meter",
+      "flag": "--no-progress-meter",
+      "type": "boolean",
+      "description": "Do not show the progress meter",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-sessionid",
+      "flag": "--no-sessionid",
+      "type": "boolean",
+      "description": "Disable SSL session-ID reusing",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "noproxy",
+      "flag": "--noproxy <no-proxy-list>",
+      "type": "string",
+      "description": "List of hosts which do not use proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ntlm",
+      "flag": "--ntlm",
+      "type": "boolean",
+      "description": "HTTP NTLM authentication",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ntlm-wb",
+      "flag": "--ntlm-wb",
+      "type": "boolean",
+      "description": "HTTP NTLM authentication with winbind",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "oauth2-bearer",
+      "flag": "--oauth2-bearer <token>",
+      "type": "string",
+      "description": "OAuth 2 Bearer Token",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "out-null",
+      "flag": "--out-null",
+      "type": "boolean",
+      "description": "Discard response data into the void",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "output",
+      "flag": "-o, --output <file>",
+      "type": "path",
+      "description": "Write to file instead of stdout",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "output-dir",
+      "flag": "--output-dir <dir>",
+      "type": "path",
+      "description": "Directory to save files in",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "parallel",
+      "flag": "-Z, --parallel",
+      "type": "boolean",
+      "description": "Perform transfers in parallel",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "parallel-immediate",
+      "flag": "--parallel-immediate",
+      "type": "boolean",
+      "description": "Do not wait for multiplexing",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "parallel-max",
+      "flag": "--parallel-max <num>",
+      "type": "number",
+      "description": "Maximum concurrency for parallel transfers",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "parallel-max-host",
+      "flag": "--parallel-max-host <num>",
+      "type": "number",
+      "description": "Maximum connections to a single host",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "pass",
+      "flag": "--pass <phrase>",
+      "type": "string",
+      "description": "Passphrase for the private key",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "path-as-is",
+      "flag": "--path-as-is",
+      "type": "boolean",
+      "description": "Do not squash .. sequences in URL path",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "pinnedpubkey",
+      "flag": "--pinnedpubkey <hashes>",
+      "type": "string",
+      "description": "Public key to verify peer against",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "post301",
+      "flag": "--post301",
+      "type": "boolean",
+      "description": "Do not switch to GET after a 301 redirect",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "post302",
+      "flag": "--post302",
+      "type": "boolean",
+      "description": "Do not switch to GET after a 302 redirect",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "post303",
+      "flag": "--post303",
+      "type": "boolean",
+      "description": "Do not switch to GET after a 303 redirect",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "preproxy",
+      "flag": "--preproxy <[protocol://]host[:port]>",
+      "type": "string",
+      "description": "Use this proxy first",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "progress-bar",
+      "flag": "-#, --progress-bar",
+      "type": "boolean",
+      "description": "Display transfer progress as a bar",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proto",
+      "flag": "--proto <protocols>",
+      "type": "string",
+      "description": "Enable/disable PROTOCOLS",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proto-default",
+      "flag": "--proto-default <protocol>",
+      "type": "string",
+      "description": "Use PROTOCOL for any URL missing a scheme",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proto-redir",
+      "flag": "--proto-redir <protocols>",
+      "type": "string",
+      "description": "Enable/disable PROTOCOLS on redirect",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy",
+      "flag": "-x, --proxy <[protocol://]host[:port]>",
+      "type": "string",
+      "description": "Use this proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-anyauth",
+      "flag": "--proxy-anyauth",
+      "type": "boolean",
+      "description": "Pick any proxy authentication method",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-basic",
+      "flag": "--proxy-basic",
+      "type": "boolean",
+      "description": "Use Basic authentication on the proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-ca-native",
+      "flag": "--proxy-ca-native",
+      "type": "boolean",
+      "description": "Load CA certs from the OS to verify proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-cacert",
+      "flag": "--proxy-cacert <file>",
+      "type": "path",
+      "description": "CA certificates to verify proxy against",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-capath",
+      "flag": "--proxy-capath <dir>",
+      "type": "path",
+      "description": "CA directory to verify proxy against",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-cert",
+      "flag": "--proxy-cert <cert[:passwd]>",
+      "type": "string",
+      "description": "Set client certificate for proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-cert-type",
+      "flag": "--proxy-cert-type <type>",
+      "type": "string",
+      "description": "Client certificate type for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-ciphers",
+      "flag": "--proxy-ciphers <list>",
+      "type": "string",
+      "description": "TLS 1.2 (1.1, 1.0) ciphers to use for proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-crlfile",
+      "flag": "--proxy-crlfile <file>",
+      "type": "path",
+      "description": "Set a CRL list for proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-digest",
+      "flag": "--proxy-digest",
+      "type": "boolean",
+      "description": "Digest auth with the proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-header",
+      "flag": "--proxy-header <header/@file>",
+      "type": "string",
+      "description": "Pass custom header(s) to proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-http2",
+      "flag": "--proxy-http2",
+      "type": "boolean",
+      "description": "Use HTTP/2 with HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-insecure",
+      "flag": "--proxy-insecure",
+      "type": "boolean",
+      "description": "Skip HTTPS proxy cert verification",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-key",
+      "flag": "--proxy-key <key>",
+      "type": "path",
+      "description": "Private key for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-key-type",
+      "flag": "--proxy-key-type <type>",
+      "type": "string",
+      "description": "Private key file type for proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-negotiate",
+      "flag": "--proxy-negotiate",
+      "type": "boolean",
+      "description": "HTTP Negotiate (SPNEGO) auth with the proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-ntlm",
+      "flag": "--proxy-ntlm",
+      "type": "boolean",
+      "description": "NTLM authentication with the proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-pass",
+      "flag": "--proxy-pass <phrase>",
+      "type": "string",
+      "description": "Passphrase for private key for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-pinnedpubkey",
+      "flag": "--proxy-pinnedpubkey <hashes>",
+      "type": "string",
+      "description": "FILE/HASHES public key to verify proxy with",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-service-name",
+      "flag": "--proxy-service-name <name>",
+      "type": "string",
+      "description": "SPNEGO proxy service name",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-ssl-allow-beast",
+      "flag": "--proxy-ssl-allow-beast",
+      "type": "boolean",
+      "description": "Allow this security flaw for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-ssl-auto-client-cert",
+      "flag": "--proxy-ssl-auto-client-cert",
+      "type": "boolean",
+      "description": "Auto client certificate for proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-tls13-ciphers",
+      "flag": "--proxy-tls13-ciphers <list>",
+      "type": "string",
+      "description": "TLS 1.3 proxy cipher suites",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-tlsauthtype",
+      "flag": "--proxy-tlsauthtype <type>",
+      "type": "string",
+      "description": "TLS authentication type for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-tlspassword",
+      "flag": "--proxy-tlspassword <string>",
+      "type": "string",
+      "description": "TLS password for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-tlsuser",
+      "flag": "--proxy-tlsuser <name>",
+      "type": "string",
+      "description": "TLS username for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-tlsv1",
+      "flag": "--proxy-tlsv1",
+      "type": "boolean",
+      "description": "TLSv1 for HTTPS proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy-user",
+      "flag": "-U, --proxy-user <user:password>",
+      "type": "string",
+      "description": "Proxy user and password",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxy1.0",
+      "flag": "--proxy1.0 <host[:port]>",
+      "type": "string",
+      "description": "Use HTTP/1.0 proxy on given port",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "proxytunnel",
+      "flag": "-p, --proxytunnel",
+      "type": "boolean",
+      "description": "HTTP proxy tunnel (using CONNECT)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "pubkey",
+      "flag": "--pubkey <key>",
+      "type": "path",
+      "description": "SSH Public key filename",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "quote",
+      "flag": "-Q, --quote <command>",
+      "type": "string",
+      "description": "Send command(s) to server before transfer",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "random-file",
+      "flag": "--random-file <file>",
+      "type": "path",
+      "description": "File for reading random data from",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "range",
+      "flag": "-r, --range <range>",
+      "type": "string",
+      "description": "Retrieve only the bytes within RANGE",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "rate",
+      "flag": "--rate <max request rate>",
+      "type": "string",
+      "description": "Request rate for serial transfers",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "raw",
+      "flag": "--raw",
+      "type": "boolean",
+      "description": "Do HTTP raw; no transfer decoding",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "referer",
+      "flag": "-e, --referer <URL>",
+      "type": "string",
+      "description": "Referrer URL",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "remote-header-name",
+      "flag": "-J, --remote-header-name",
+      "type": "boolean",
+      "description": "Use the header-provided filename",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "remote-name",
+      "flag": "-O, --remote-name",
+      "type": "boolean",
+      "description": "Write output to file named as remote file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "remote-name-all",
+      "flag": "--remote-name-all",
+      "type": "boolean",
+      "description": "Use the remote filename for all URLs",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "remote-time",
+      "flag": "-R, --remote-time",
+      "type": "boolean",
+      "description": "Set remote file's time on local output",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "remove-on-error",
+      "flag": "--remove-on-error",
+      "type": "boolean",
+      "description": "Remove output file on errors",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "request",
+      "flag": "-X, --request <method>",
+      "type": "string",
+      "description": "Specify request method to use",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "request-target",
+      "flag": "--request-target <path>",
+      "type": "string",
+      "description": "Specify the target for this request",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "resolve",
+      "flag": "--resolve <[+]host:port:addr[,addr]...>",
+      "type": "string",
+      "description": "Resolve host+port to address",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "retry",
+      "flag": "--retry <num>",
+      "type": "number",
+      "description": "Retry request if transient problems occur",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "retry-all-errors",
+      "flag": "--retry-all-errors",
+      "type": "boolean",
+      "description": "Retry all errors (with --retry)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "retry-connrefused",
+      "flag": "--retry-connrefused",
+      "type": "boolean",
+      "description": "Retry on connection refused (with --retry)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "retry-delay",
+      "flag": "--retry-delay <seconds>",
+      "type": "number",
+      "description": "Wait time between retries",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "retry-max-time",
+      "flag": "--retry-max-time <seconds>",
+      "type": "number",
+      "description": "Retry only within this period",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "sasl-authzid",
+      "flag": "--sasl-authzid <identity>",
+      "type": "string",
+      "description": "Identity for SASL PLAIN authentication",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "sasl-ir",
+      "flag": "--sasl-ir",
+      "type": "boolean",
+      "description": "Initial response in SASL authentication",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "service-name",
+      "flag": "--service-name <name>",
+      "type": "string",
+      "description": "SPNEGO service name",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "show-error",
+      "flag": "-S, --show-error",
+      "type": "boolean",
+      "description": "Show error even when -s is used",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "show-headers",
+      "flag": "-i, --show-headers",
+      "type": "boolean",
+      "description": "Show response headers in output",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "sigalgs",
+      "flag": "--sigalgs <list>",
+      "type": "string",
+      "description": "TLS signature algorithms to use",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "silent",
+      "flag": "-s, --silent",
+      "type": "boolean",
+      "description": "Silent mode",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "skip-existing",
+      "flag": "--skip-existing",
+      "type": "boolean",
+      "description": "Skip download if local file already exists",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks4",
+      "flag": "--socks4 <host[:port]>",
+      "type": "string",
+      "description": "SOCKS4 proxy on given host + port",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks4a",
+      "flag": "--socks4a <host[:port]>",
+      "type": "string",
+      "description": "SOCKS4a proxy on given host + port",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks5",
+      "flag": "--socks5 <host[:port]>",
+      "type": "string",
+      "description": "SOCKS5 proxy on given host + port",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks5-basic",
+      "flag": "--socks5-basic",
+      "type": "boolean",
+      "description": "Username/password auth for SOCKS5 proxies",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks5-gssapi",
+      "flag": "--socks5-gssapi",
+      "type": "boolean",
+      "description": "Enable GSS-API auth for SOCKS5 proxies",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks5-gssapi-nec",
+      "flag": "--socks5-gssapi-nec",
+      "type": "boolean",
+      "description": "Compatibility with NEC SOCKS5 server",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks5-gssapi-service",
+      "flag": "--socks5-gssapi-service <name>",
+      "type": "string",
+      "description": "SOCKS5 proxy service name for GSS-API",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "socks5-hostname",
+      "flag": "--socks5-hostname <host[:port]>",
+      "type": "string",
+      "description": "SOCKS5 proxy, pass hostname to proxy",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "speed-limit",
+      "flag": "-Y, --speed-limit <speed>",
+      "type": "number",
+      "description": "Stop transfers slower than this",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "speed-time",
+      "flag": "-y, --speed-time <seconds>",
+      "type": "number",
+      "description": "Trigger 'speed-limit' abort after this time",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ssl",
+      "flag": "--ssl",
+      "type": "boolean",
+      "description": "Try enabling TLS",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ssl-allow-beast",
+      "flag": "--ssl-allow-beast",
+      "type": "boolean",
+      "description": "Allow security flaw to improve interop",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ssl-auto-client-cert",
+      "flag": "--ssl-auto-client-cert",
+      "type": "boolean",
+      "description": "Use auto client certificate (Schannel)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ssl-no-revoke",
+      "flag": "--ssl-no-revoke",
+      "type": "boolean",
+      "description": "Disable cert revocation checks (Schannel)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ssl-reqd",
+      "flag": "--ssl-reqd",
+      "type": "boolean",
+      "description": "Require SSL/TLS",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ssl-revoke-best-effort",
+      "flag": "--ssl-revoke-best-effort",
+      "type": "boolean",
+      "description": "Ignore missing cert CRL dist points",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "ssl-sessions",
+      "flag": "--ssl-sessions <filename>",
+      "type": "path",
+      "description": "Load/save SSL session tickets from/to this file",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "sslv2",
+      "flag": "-2, --sslv2",
+      "type": "boolean",
+      "description": "SSLv2",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "sslv3",
+      "flag": "-3, --sslv3",
+      "type": "boolean",
+      "description": "SSLv3",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "stderr",
+      "flag": "--stderr <file>",
+      "type": "path",
+      "description": "Where to redirect stderr",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "styled-output",
+      "flag": "--styled-output",
+      "type": "boolean",
+      "description": "Enable styled output for HTTP headers",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "suppress-connect-headers",
+      "flag": "--suppress-connect-headers",
+      "type": "boolean",
+      "description": "Suppress proxy CONNECT response headers",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tcp-fastopen",
+      "flag": "--tcp-fastopen",
+      "type": "boolean",
+      "description": "Use TCP Fast Open",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tcp-nodelay",
+      "flag": "--tcp-nodelay",
+      "type": "boolean",
+      "description": "Set TCP_NODELAY",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "telnet-option",
+      "flag": "-t, --telnet-option <opt=val>",
+      "type": "string",
+      "description": "Set telnet option",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tftp-blksize",
+      "flag": "--tftp-blksize <value>",
+      "type": "number",
+      "description": "Set TFTP BLKSIZE option",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tftp-no-options",
+      "flag": "--tftp-no-options",
+      "type": "boolean",
+      "description": "Do not send any TFTP options",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "time-cond",
+      "flag": "-z, --time-cond <time>",
+      "type": "string",
+      "description": "Transfer based on a time condition",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tls-earlydata",
+      "flag": "--tls-earlydata",
+      "type": "boolean",
+      "description": "Allow use of TLSv1.3 early data (0RTT)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tls-max",
+      "flag": "--tls-max <VERSION>",
+      "type": "string",
+      "description": "Maximum allowed TLS version",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tls13-ciphers",
+      "flag": "--tls13-ciphers <list>",
+      "type": "string",
+      "description": "TLS 1.3 cipher suites to use",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlsauthtype",
+      "flag": "--tlsauthtype <type>",
+      "type": "string",
+      "description": "TLS authentication type",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlspassword",
+      "flag": "--tlspassword <string>",
+      "type": "string",
+      "description": "TLS password",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlsuser",
+      "flag": "--tlsuser <name>",
+      "type": "string",
+      "description": "TLS username",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlsv1",
+      "flag": "-1, --tlsv1",
+      "type": "boolean",
+      "description": "TLSv1.0 or greater",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlsv1.0",
+      "flag": "--tlsv1.0",
+      "type": "boolean",
+      "description": "TLSv1.0 or greater",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlsv1.1",
+      "flag": "--tlsv1.1",
+      "type": "boolean",
+      "description": "TLSv1.1 or greater",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlsv1.2",
+      "flag": "--tlsv1.2",
+      "type": "boolean",
+      "description": "TLSv1.2 or greater",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tlsv1.3",
+      "flag": "--tlsv1.3",
+      "type": "boolean",
+      "description": "TLSv1.3 or greater",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "tr-encoding",
+      "flag": "--tr-encoding",
+      "type": "boolean",
+      "description": "Request compressed transfer encoding",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "trace",
+      "flag": "--trace <file>",
+      "type": "path",
+      "description": "Write a debug trace to FILE",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "trace-ascii",
+      "flag": "--trace-ascii <file>",
+      "type": "path",
+      "description": "Like --trace, but without hex output",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "trace-config",
+      "flag": "--trace-config <string>",
+      "type": "string",
+      "description": "Details to log in trace/verbose output",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "trace-ids",
+      "flag": "--trace-ids",
+      "type": "boolean",
+      "description": "Transfer + connection ids in verbose output",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "trace-time",
+      "flag": "--trace-time",
+      "type": "boolean",
+      "description": "Add time stamps to trace/verbose output",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "unix-socket",
+      "flag": "--unix-socket <path>",
+      "type": "path",
+      "description": "Connect through this Unix domain socket",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "upload-file",
+      "flag": "-T, --upload-file <file>",
+      "type": "path",
+      "description": "Transfer local FILE to destination",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "upload-flags",
+      "flag": "--upload-flags <flags>",
+      "type": "string",
+      "description": "IMAP upload behavior",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "url",
+      "flag": "--url <url/file>",
+      "type": "string",
+      "description": "URL(s) to work with",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "url-query",
+      "flag": "--url-query <data>",
+      "type": "string",
+      "description": "Add a URL query part",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "use-ascii",
+      "flag": "-B, --use-ascii",
+      "type": "boolean",
+      "description": "Use ASCII/text transfer",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "user",
+      "flag": "-u, --user <user:password>",
+      "type": "string",
+      "description": "Server user and password",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "user-agent",
+      "flag": "-A, --user-agent <name>",
+      "type": "string",
+      "description": "Send User-Agent to server",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "variable",
+      "flag": "--variable <[%]name=text/@file>",
+      "type": "string",
+      "description": "Set variable",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "verbose",
+      "flag": "-v, --verbose",
+      "type": "boolean",
+      "description": "Make the operation more talkative",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "version",
+      "flag": "-V, --version",
+      "type": "boolean",
+      "description": "Show version number and quit",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "vlan-priority",
+      "flag": "--vlan-priority <priority>",
+      "type": "number",
+      "description": "Set VLAN priority",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "write-out",
+      "flag": "-w, --write-out <format>",
+      "type": "string",
+      "description": "Output FORMAT after completion",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "xattr",
+      "flag": "--xattr",
+      "type": "boolean",
+      "description": "Store metadata in extended file attributes",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    }
+  ],
+  "positionals": [
+    {
+      "name": "url",
+      "type": "string",
+      "description": "URL(s) to transfer data from or to",
+      "required": false,
+      "variadic": true
+    }
+  ]
+}

--- a/schemas/jq.json
+++ b/schemas/jq.json
@@ -1,0 +1,292 @@
+{
+  "tool": "jq",
+  "summary": "commandline JSON processor",
+  "options": [
+    {
+      "name": "null-input",
+      "flag": "-n, --null-input",
+      "type": "boolean",
+      "description": "use `null` as the single input value",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "raw-input",
+      "flag": "-R, --raw-input",
+      "type": "boolean",
+      "description": "read each line as string instead of JSON",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "slurp",
+      "flag": "-s, --slurp",
+      "type": "boolean",
+      "description": "read all inputs into an array and use it as the single input value",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "compact-output",
+      "flag": "-c, --compact-output",
+      "type": "boolean",
+      "description": "compact instead of pretty-printed output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "raw-output",
+      "flag": "-r, --raw-output",
+      "type": "boolean",
+      "description": "output strings without escapes and quotes",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "raw-output0",
+      "flag": "--raw-output0",
+      "type": "boolean",
+      "description": "implies -r and output NUL after each output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "join-output",
+      "flag": "-j, --join-output",
+      "type": "boolean",
+      "description": "implies -r and output without newline after each output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "ascii-output",
+      "flag": "-a, --ascii-output",
+      "type": "boolean",
+      "description": "output strings by only ASCII characters using escape sequences",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "sort-keys",
+      "flag": "-S, --sort-keys",
+      "type": "boolean",
+      "description": "sort keys of each object on output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "color-output",
+      "flag": "-C, --color-output",
+      "type": "boolean",
+      "description": "colorize JSON output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "monochrome-output",
+      "flag": "-M, --monochrome-output",
+      "type": "boolean",
+      "description": "disable colored output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "tab",
+      "flag": "--tab",
+      "type": "boolean",
+      "description": "use tabs for indentation",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "indent",
+      "flag": "--indent",
+      "type": "number",
+      "description": "use n spaces for indentation (max 7 spaces)",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "unbuffered",
+      "flag": "--unbuffered",
+      "type": "boolean",
+      "description": "flush output stream after each output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "stream",
+      "flag": "--stream",
+      "type": "boolean",
+      "description": "parse the input value in streaming fashion",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "stream-errors",
+      "flag": "--stream-errors",
+      "type": "boolean",
+      "description": "implies --stream and report parse error as an array",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "seq",
+      "flag": "--seq",
+      "type": "boolean",
+      "description": "parse input/output as application/json-seq",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "from-file",
+      "flag": "-f, --from-file",
+      "type": "path",
+      "description": "load the filter from a file",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "library-path",
+      "flag": "-L, --library-path",
+      "type": "path",
+      "description": "search modules from the directory",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "arg",
+      "flag": "--arg",
+      "type": "string",
+      "description": "set $name to the string value",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "argjson",
+      "flag": "--argjson",
+      "type": "string",
+      "description": "set $name to the JSON value",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "slurpfile",
+      "flag": "--slurpfile",
+      "type": "path",
+      "description": "set $name to an array of JSON values read from the file",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "rawfile",
+      "flag": "--rawfile",
+      "type": "path",
+      "description": "set $name to string contents of file",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "args",
+      "flag": "--args",
+      "type": "boolean",
+      "description": "consume remaining arguments as positional string values",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "jsonargs",
+      "flag": "--jsonargs",
+      "type": "boolean",
+      "description": "consume remaining arguments as positional JSON values",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "exit-status",
+      "flag": "-e, --exit-status",
+      "type": "boolean",
+      "description": "set exit status code based on the output",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "binary",
+      "flag": "-b, --binary",
+      "type": "boolean",
+      "description": "open input/output streams in binary mode",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "version",
+      "flag": "-V, --version",
+      "type": "boolean",
+      "description": "show the version",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "build-configuration",
+      "flag": "--build-configuration",
+      "type": "boolean",
+      "description": "show jq's build configuration",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    },
+    {
+      "name": "help",
+      "flag": "-h, --help",
+      "type": "boolean",
+      "description": "show the help",
+      "enumValues": [],
+      "required": false,
+      "group": "Command options"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "jq filter",
+      "type": "string",
+      "description": "jq filter expression to apply to JSON input",
+      "required": true,
+      "variadic": false
+    },
+    {
+      "name": "file",
+      "type": "path",
+      "description": "input JSON file(s) to process",
+      "required": false,
+      "variadic": true
+    }
+  ]
+}

--- a/schemas/magick.json
+++ b/schemas/magick.json
@@ -1,0 +1,2395 @@
+{
+  "tool": "magick",
+  "summary": "ImageMagick image processing and conversion tool",
+  "options": [
+    {
+      "name": "adjoin",
+      "flag": "-adjoin",
+      "type": "boolean",
+      "description": "join images into a single multi-image file",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "affine",
+      "flag": "-affine",
+      "type": "string",
+      "description": "affine transform matrix",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "alpha",
+      "flag": "-alpha",
+      "type": "enum",
+      "description": "activate, deactivate, reset, or set the alpha channel",
+      "enumValues": [
+        "on",
+        "activate",
+        "off",
+        "deactivate",
+        "set",
+        "opaque",
+        "copy",
+        "transparent",
+        "extract",
+        "background",
+        "shape"
+      ],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "antialias",
+      "flag": "-antialias",
+      "type": "boolean",
+      "description": "remove pixel-aliasing",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "authenticate",
+      "flag": "-authenticate",
+      "type": "string",
+      "description": "decipher image with this password",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "attenuate",
+      "flag": "-attenuate",
+      "type": "number",
+      "description": "lessen (or intensify) when adding noise to an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "background",
+      "flag": "-background",
+      "type": "string",
+      "description": "background color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "bias",
+      "flag": "-bias",
+      "type": "string",
+      "description": "add bias when convolving an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "black-point-compensation",
+      "flag": "-black-point-compensation",
+      "type": "boolean",
+      "description": "use black point compensation",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "blue-primary",
+      "flag": "-blue-primary",
+      "type": "string",
+      "description": "chromaticity blue primary point",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "bordercolor",
+      "flag": "-bordercolor",
+      "type": "string",
+      "description": "border color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "caption",
+      "flag": "-caption",
+      "type": "string",
+      "description": "assign a caption to an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "clip",
+      "flag": "-clip",
+      "type": "boolean",
+      "description": "clip along the first path from the 8BIM profile",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "clip-mask",
+      "flag": "-clip-mask",
+      "type": "path",
+      "description": "associate a clip mask with the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "clip-path",
+      "flag": "-clip-path",
+      "type": "string",
+      "description": "clip along a named path from the 8BIM profile",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "colorspace",
+      "flag": "-colorspace",
+      "type": "string",
+      "description": "alternate image colorspace",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "comment",
+      "flag": "-comment",
+      "type": "string",
+      "description": "annotate image with comment",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "compose",
+      "flag": "-compose",
+      "type": "string",
+      "description": "set image composite operator",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "compress",
+      "flag": "-compress",
+      "type": "string",
+      "description": "type of pixel compression when writing the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "define",
+      "flag": "-define",
+      "type": "string",
+      "description": "define one or more image format options",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "delay",
+      "flag": "-delay",
+      "type": "string",
+      "description": "display the next image after pausing",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "density",
+      "flag": "-density",
+      "type": "string",
+      "description": "horizontal and vertical density of the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "depth",
+      "flag": "-depth",
+      "type": "number",
+      "description": "image depth",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "direction",
+      "flag": "-direction",
+      "type": "string",
+      "description": "render text right-to-left or left-to-right",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "display",
+      "flag": "-display",
+      "type": "string",
+      "description": "get image or font from this X server",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "dispose",
+      "flag": "-dispose",
+      "type": "string",
+      "description": "layer disposal method",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "dither",
+      "flag": "-dither",
+      "type": "string",
+      "description": "apply error diffusion to image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "encoding",
+      "flag": "-encoding",
+      "type": "string",
+      "description": "text encoding type",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "endian",
+      "flag": "-endian",
+      "type": "enum",
+      "description": "endianness (MSB or LSB) of the image",
+      "enumValues": [
+        "MSB",
+        "LSB"
+      ],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "family",
+      "flag": "-family",
+      "type": "string",
+      "description": "render text with this font family",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "features",
+      "flag": "-features",
+      "type": "string",
+      "description": "analyze image features (e.g. contrast, correlation)",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "fill",
+      "flag": "-fill",
+      "type": "string",
+      "description": "color to use when filling a graphic primitive",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "filter",
+      "flag": "-filter",
+      "type": "string",
+      "description": "use this filter when resizing an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "font",
+      "flag": "-font",
+      "type": "string",
+      "description": "render text with this font",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "format",
+      "flag": "-format",
+      "type": "string",
+      "description": "output formatted image characteristics",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "fuzz",
+      "flag": "-fuzz",
+      "type": "string",
+      "description": "colors within this distance are considered equal",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "gravity",
+      "flag": "-gravity",
+      "type": "string",
+      "description": "horizontal and vertical text placement",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "green-primary",
+      "flag": "-green-primary",
+      "type": "string",
+      "description": "chromaticity green primary point",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "illuminant",
+      "flag": "-illuminant",
+      "type": "string",
+      "description": "reference illuminant",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "intensity",
+      "flag": "-intensity",
+      "type": "string",
+      "description": "method to generate an intensity value from a pixel",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "intent",
+      "flag": "-intent",
+      "type": "string",
+      "description": "type of rendering intent when managing the image color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "interlace",
+      "flag": "-interlace",
+      "type": "string",
+      "description": "type of image interlacing scheme",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "interline-spacing",
+      "flag": "-interline-spacing",
+      "type": "number",
+      "description": "set the space between two text lines",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "interpolate",
+      "flag": "-interpolate",
+      "type": "string",
+      "description": "pixel color interpolation method",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "interword-spacing",
+      "flag": "-interword-spacing",
+      "type": "number",
+      "description": "set the space between two words",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "kerning",
+      "flag": "-kerning",
+      "type": "number",
+      "description": "set the space between two letters",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "label",
+      "flag": "-label",
+      "type": "string",
+      "description": "assign a label to an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "limit",
+      "flag": "-limit",
+      "type": "string",
+      "description": "pixel cache resource limit",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "loop",
+      "flag": "-loop",
+      "type": "number",
+      "description": "add Netscape loop extension to your GIF animation",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "matte",
+      "flag": "-matte",
+      "type": "boolean",
+      "description": "store matte channel if the image has one",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "mattecolor",
+      "flag": "-mattecolor",
+      "type": "string",
+      "description": "frame color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "moments",
+      "flag": "-moments",
+      "type": "boolean",
+      "description": "report image moments",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "monitor",
+      "flag": "-monitor",
+      "type": "boolean",
+      "description": "monitor progress",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "orient",
+      "flag": "-orient",
+      "type": "string",
+      "description": "image orientation",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "page",
+      "flag": "-page",
+      "type": "string",
+      "description": "size and location of an image canvas (setting)",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "ping",
+      "flag": "-ping",
+      "type": "boolean",
+      "description": "efficiently determine image attributes",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "pointsize",
+      "flag": "-pointsize",
+      "type": "number",
+      "description": "font point size",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "precision",
+      "flag": "-precision",
+      "type": "number",
+      "description": "maximum number of significant digits to print",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "preview",
+      "flag": "-preview",
+      "type": "string",
+      "description": "image preview type",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "quality",
+      "flag": "-quality",
+      "type": "number",
+      "description": "JPEG/MIFF/PNG compression level",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "quiet",
+      "flag": "-quiet",
+      "type": "boolean",
+      "description": "suppress all warning messages",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "read-mask",
+      "flag": "-read-mask",
+      "type": "path",
+      "description": "associate a read mask with the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "red-primary",
+      "flag": "-red-primary",
+      "type": "string",
+      "description": "chromaticity red primary point",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "regard-warnings",
+      "flag": "-regard-warnings",
+      "type": "boolean",
+      "description": "pay attention to warning messages",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "remap",
+      "flag": "-remap",
+      "type": "path",
+      "description": "transform image colors to match this set of colors",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "repage",
+      "flag": "-repage",
+      "type": "string",
+      "description": "size and location of an image canvas",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "respect-parentheses",
+      "flag": "-respect-parentheses",
+      "type": "boolean",
+      "description": "settings remain in effect until parenthesis boundary",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "sampling-factor",
+      "flag": "-sampling-factor",
+      "type": "string",
+      "description": "horizontal and vertical sampling factor",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "scene",
+      "flag": "-scene",
+      "type": "number",
+      "description": "image scene number",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "seed",
+      "flag": "-seed",
+      "type": "number",
+      "description": "seed a new sequence of pseudo-random numbers",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "size",
+      "flag": "-size",
+      "type": "string",
+      "description": "width and height of image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "stretch",
+      "flag": "-stretch",
+      "type": "string",
+      "description": "render text with this font stretch",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "stroke",
+      "flag": "-stroke",
+      "type": "string",
+      "description": "graphic primitive stroke color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "strokewidth",
+      "flag": "-strokewidth",
+      "type": "number",
+      "description": "graphic primitive stroke width",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "style",
+      "flag": "-style",
+      "type": "string",
+      "description": "render text with this font style",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "support",
+      "flag": "-support",
+      "type": "number",
+      "description": "resize support: > 1.0 is blurry, < 1.0 is sharp",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "synchronize",
+      "flag": "-synchronize",
+      "type": "boolean",
+      "description": "synchronize image to storage device",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "taint",
+      "flag": "-taint",
+      "type": "boolean",
+      "description": "declare the image as modified",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "texture",
+      "flag": "-texture",
+      "type": "path",
+      "description": "name of texture to tile onto the image background",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "tile-offset",
+      "flag": "-tile-offset",
+      "type": "string",
+      "description": "tile offset",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "treedepth",
+      "flag": "-treedepth",
+      "type": "number",
+      "description": "color tree depth",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "transparent-color",
+      "flag": "-transparent-color",
+      "type": "string",
+      "description": "transparent color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "undercolor",
+      "flag": "-undercolor",
+      "type": "string",
+      "description": "annotation bounding box color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "units",
+      "flag": "-units",
+      "type": "string",
+      "description": "the units of image resolution",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "verbose",
+      "flag": "-verbose",
+      "type": "boolean",
+      "description": "print detailed information about the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "view",
+      "flag": "-view",
+      "type": "boolean",
+      "description": "FlashPix viewing transforms",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "virtual-pixel",
+      "flag": "-virtual-pixel",
+      "type": "string",
+      "description": "virtual pixel access method",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "weight",
+      "flag": "-weight",
+      "type": "string",
+      "description": "render text with this font weight",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "white-point",
+      "flag": "-white-point",
+      "type": "string",
+      "description": "chromaticity white point",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "write-mask",
+      "flag": "-write-mask",
+      "type": "path",
+      "description": "associate a write mask with the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "word-break",
+      "flag": "-word-break",
+      "type": "string",
+      "description": "sets whether line breaks appear wherever the text would otherwise overflow",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Settings"
+    },
+    {
+      "name": "adaptive-blur",
+      "flag": "-adaptive-blur",
+      "type": "string",
+      "description": "adaptively blur pixels; decrease effect near edges",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "adaptive-resize",
+      "flag": "-adaptive-resize",
+      "type": "string",
+      "description": "adaptively resize image using 'mesh' interpolation",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "adaptive-sharpen",
+      "flag": "-adaptive-sharpen",
+      "type": "string",
+      "description": "adaptively sharpen pixels; increase effect near edges",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "annotate",
+      "flag": "-annotate",
+      "type": "string",
+      "description": "annotate the image with text",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "auto-gamma",
+      "flag": "-auto-gamma",
+      "type": "boolean",
+      "description": "automagically adjust gamma level of image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "auto-level",
+      "flag": "-auto-level",
+      "type": "boolean",
+      "description": "automagically adjust color levels of image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "auto-orient",
+      "flag": "-auto-orient",
+      "type": "boolean",
+      "description": "automagically orient (rotate) image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "auto-threshold",
+      "flag": "-auto-threshold",
+      "type": "string",
+      "description": "automatically perform image thresholding",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "bench",
+      "flag": "-bench",
+      "type": "number",
+      "description": "measure performance",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "bilateral-blur",
+      "flag": "-bilateral-blur",
+      "type": "string",
+      "description": "non-linear, edge-preserving, and noise-reducing smoothing filter",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "black-threshold",
+      "flag": "-black-threshold",
+      "type": "string",
+      "description": "force all pixels below the threshold into black",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "blue-shift",
+      "flag": "-blue-shift",
+      "type": "number",
+      "description": "simulate a scene at nighttime in the moonlight",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "blur",
+      "flag": "-blur",
+      "type": "string",
+      "description": "reduce image noise and reduce detail levels",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "border",
+      "flag": "-border",
+      "type": "string",
+      "description": "surround image with a border of color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "brightness-contrast",
+      "flag": "-brightness-contrast",
+      "type": "string",
+      "description": "improve brightness / contrast of the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "canny",
+      "flag": "-canny",
+      "type": "string",
+      "description": "detect edges in the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "cdl",
+      "flag": "-cdl",
+      "type": "path",
+      "description": "color correct with a color decision list",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "channel",
+      "flag": "-channel",
+      "type": "string",
+      "description": "set the image channel mask",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "charcoal",
+      "flag": "-charcoal",
+      "type": "number",
+      "description": "simulate a charcoal drawing",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "chop",
+      "flag": "-chop",
+      "type": "string",
+      "description": "remove pixels from the image interior",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "clahe",
+      "flag": "-clahe",
+      "type": "string",
+      "description": "contrast limited adaptive histogram equalization",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "clamp",
+      "flag": "-clamp",
+      "type": "boolean",
+      "description": "keep pixel values in range (0-QuantumRange)",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "colorize",
+      "flag": "-colorize",
+      "type": "string",
+      "description": "colorize the image with the fill color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "color-matrix",
+      "flag": "-color-matrix",
+      "type": "string",
+      "description": "apply color correction to the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "colors",
+      "flag": "-colors",
+      "type": "number",
+      "description": "preferred number of colors in the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "connected-components",
+      "flag": "-connected-components",
+      "type": "number",
+      "description": "connected-components uniquely labeled",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "contrast",
+      "flag": "-contrast",
+      "type": "boolean",
+      "description": "enhance or reduce the image contrast",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "contrast-stretch",
+      "flag": "-contrast-stretch",
+      "type": "string",
+      "description": "improve contrast by 'stretching' the intensity range",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "convolve",
+      "flag": "-convolve",
+      "type": "string",
+      "description": "apply a convolution kernel to the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "cycle",
+      "flag": "-cycle",
+      "type": "number",
+      "description": "cycle the image colormap",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "decipher",
+      "flag": "-decipher",
+      "type": "path",
+      "description": "convert cipher pixels to plain pixels",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "deskew",
+      "flag": "-deskew",
+      "type": "string",
+      "description": "straighten an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "despeckle",
+      "flag": "-despeckle",
+      "type": "boolean",
+      "description": "reduce the speckles within an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "distort",
+      "flag": "-distort",
+      "type": "string",
+      "description": "distort images according to given method and args",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "draw",
+      "flag": "-draw",
+      "type": "string",
+      "description": "annotate the image with a graphic primitive",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "edge",
+      "flag": "-edge",
+      "type": "number",
+      "description": "apply a filter to detect edges in the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "encipher",
+      "flag": "-encipher",
+      "type": "path",
+      "description": "convert plain pixels to cipher pixels",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "emboss",
+      "flag": "-emboss",
+      "type": "number",
+      "description": "emboss an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "enhance",
+      "flag": "-enhance",
+      "type": "boolean",
+      "description": "apply a digital filter to enhance a noisy image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "equalize",
+      "flag": "-equalize",
+      "type": "boolean",
+      "description": "perform histogram equalization to an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "evaluate",
+      "flag": "-evaluate",
+      "type": "string",
+      "description": "evaluate an arithmetic, relational, or logical expression",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "extent",
+      "flag": "-extent",
+      "type": "string",
+      "description": "set the image size",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "extract",
+      "flag": "-extract",
+      "type": "string",
+      "description": "extract area from image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "fft",
+      "flag": "-fft",
+      "type": "boolean",
+      "description": "implements the discrete Fourier transform (DFT)",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "flip",
+      "flag": "-flip",
+      "type": "boolean",
+      "description": "flip image vertically",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "floodfill",
+      "flag": "-floodfill",
+      "type": "string",
+      "description": "floodfill the image with color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "flop",
+      "flag": "-flop",
+      "type": "boolean",
+      "description": "flop image horizontally",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "frame",
+      "flag": "-frame",
+      "type": "string",
+      "description": "surround image with an ornamental border",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "function",
+      "flag": "-function",
+      "type": "string",
+      "description": "apply function over image values",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "gamma",
+      "flag": "-gamma",
+      "type": "number",
+      "description": "level of gamma correction",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "gaussian-blur",
+      "flag": "-gaussian-blur",
+      "type": "string",
+      "description": "reduce image noise and reduce detail levels",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "geometry",
+      "flag": "-geometry",
+      "type": "string",
+      "description": "preferred size or location of the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "grayscale",
+      "flag": "-grayscale",
+      "type": "string",
+      "description": "convert image to grayscale",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "hough-lines",
+      "flag": "-hough-lines",
+      "type": "string",
+      "description": "identify lines in the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "identify",
+      "flag": "-identify",
+      "type": "boolean",
+      "description": "identify the format and characteristics of the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "ift",
+      "flag": "-ift",
+      "type": "boolean",
+      "description": "implements the inverse discrete Fourier transform (DFT)",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "implode",
+      "flag": "-implode",
+      "type": "number",
+      "description": "implode image pixels about the center",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "integral",
+      "flag": "-integral",
+      "type": "boolean",
+      "description": "calculate the sum of values (pixel values) in the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "interpolative-resize",
+      "flag": "-interpolative-resize",
+      "type": "string",
+      "description": "resize image using interpolation",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "kmeans",
+      "flag": "-kmeans",
+      "type": "string",
+      "description": "K means color reduction",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "kuwahara",
+      "flag": "-kuwahara",
+      "type": "string",
+      "description": "edge preserving noise reduction filter",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "lat",
+      "flag": "-lat",
+      "type": "string",
+      "description": "local adaptive thresholding",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "level",
+      "flag": "-level",
+      "type": "string",
+      "description": "adjust the level of image contrast",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "level-colors",
+      "flag": "-level-colors",
+      "type": "string",
+      "description": "level image with the given colors",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "linear-stretch",
+      "flag": "-linear-stretch",
+      "type": "string",
+      "description": "improve contrast by 'stretching with saturation'",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "liquid-rescale",
+      "flag": "-liquid-rescale",
+      "type": "string",
+      "description": "rescale image with seam-carving",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "local-contrast",
+      "flag": "-local-contrast",
+      "type": "string",
+      "description": "enhance local contrast",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "mean-shift",
+      "flag": "-mean-shift",
+      "type": "string",
+      "description": "delineate arbitrarily shaped clusters in the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "median",
+      "flag": "-median",
+      "type": "string",
+      "description": "apply a median filter to the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "mode",
+      "flag": "-mode",
+      "type": "string",
+      "description": "make each pixel the 'predominant color' of the neighborhood",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "modulate",
+      "flag": "-modulate",
+      "type": "string",
+      "description": "vary the brightness, saturation, and hue",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "monochrome",
+      "flag": "-monochrome",
+      "type": "boolean",
+      "description": "transform image to black and white",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "morphology",
+      "flag": "-morphology",
+      "type": "string",
+      "description": "apply a morphology method to the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "motion-blur",
+      "flag": "-motion-blur",
+      "type": "string",
+      "description": "simulate motion blur",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "negate",
+      "flag": "-negate",
+      "type": "boolean",
+      "description": "replace every pixel with its complementary color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "noise",
+      "flag": "-noise",
+      "type": "string",
+      "description": "add or reduce noise in an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "normalize",
+      "flag": "-normalize",
+      "type": "boolean",
+      "description": "transform image to span the full range of colors",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "opaque",
+      "flag": "-opaque",
+      "type": "string",
+      "description": "change this color to the fill color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "ordered-dither",
+      "flag": "-ordered-dither",
+      "type": "string",
+      "description": "add a noise pattern to the image with specific amplitudes",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "paint",
+      "flag": "-paint",
+      "type": "number",
+      "description": "simulate an oil painting",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "perceptible",
+      "flag": "-perceptible",
+      "type": "number",
+      "description": "pixel value less than |epsilon| become epsilon or -epsilon",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "polaroid",
+      "flag": "-polaroid",
+      "type": "number",
+      "description": "simulate a Polaroid picture",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "posterize",
+      "flag": "-posterize",
+      "type": "number",
+      "description": "reduce the image to a limited number of color levels",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "profile",
+      "flag": "-profile",
+      "type": "path",
+      "description": "add, delete, or apply an image profile",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "quantize",
+      "flag": "-quantize",
+      "type": "string",
+      "description": "reduce colors in this colorspace",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "raise",
+      "flag": "-raise",
+      "type": "string",
+      "description": "lighten/darken image edges to create a 3-D effect",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "random-threshold",
+      "flag": "-random-threshold",
+      "type": "string",
+      "description": "random threshold the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "range-threshold",
+      "flag": "-range-threshold",
+      "type": "string",
+      "description": "perform either hard or soft thresholding within some range of values in an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "region",
+      "flag": "-region",
+      "type": "string",
+      "description": "apply options to a portion of the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "render",
+      "flag": "-render",
+      "type": "boolean",
+      "description": "render vector graphics",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "resample",
+      "flag": "-resample",
+      "type": "string",
+      "description": "change the resolution of an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "reshape",
+      "flag": "-reshape",
+      "type": "string",
+      "description": "reshape the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "resize",
+      "flag": "-resize",
+      "type": "string",
+      "description": "resize the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "roll",
+      "flag": "-roll",
+      "type": "string",
+      "description": "roll an image vertically or horizontally",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "rotate",
+      "flag": "-rotate",
+      "type": "number",
+      "description": "apply Paeth rotation to the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "rotational-blur",
+      "flag": "-rotational-blur",
+      "type": "number",
+      "description": "rotational blur the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "sample",
+      "flag": "-sample",
+      "type": "string",
+      "description": "scale image with pixel sampling",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "scale",
+      "flag": "-scale",
+      "type": "string",
+      "description": "scale the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "segment",
+      "flag": "-segment",
+      "type": "string",
+      "description": "segment an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "selective-blur",
+      "flag": "-selective-blur",
+      "type": "string",
+      "description": "selectively blur pixels within a contrast threshold",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "sepia-tone",
+      "flag": "-sepia-tone",
+      "type": "string",
+      "description": "simulate a sepia-toned photo",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "set",
+      "flag": "-set",
+      "type": "string",
+      "description": "set an image property",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "shade",
+      "flag": "-shade",
+      "type": "number",
+      "description": "shade the image using a distant light source",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "shadow",
+      "flag": "-shadow",
+      "type": "string",
+      "description": "simulate an image shadow",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "sharpen",
+      "flag": "-sharpen",
+      "type": "string",
+      "description": "sharpen the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "shave",
+      "flag": "-shave",
+      "type": "string",
+      "description": "shave pixels from the image edges",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "shear",
+      "flag": "-shear",
+      "type": "string",
+      "description": "slide one edge of the image along the X or Y axis",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "sigmoidal-contrast",
+      "flag": "-sigmoidal-contrast",
+      "type": "string",
+      "description": "increase the contrast without saturating highlights or shadows",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "sketch",
+      "flag": "-sketch",
+      "type": "string",
+      "description": "simulate a pencil sketch",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "solarize",
+      "flag": "-solarize",
+      "type": "string",
+      "description": "negate all pixels above the threshold level",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "sort-pixels",
+      "flag": "-sort-pixels",
+      "type": "boolean",
+      "description": "sort each scanline in ascending order of intensity",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "sparse-color",
+      "flag": "-sparse-color",
+      "type": "string",
+      "description": "fill in a image based on a few color points",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "splice",
+      "flag": "-splice",
+      "type": "string",
+      "description": "splice the background color into the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "spread",
+      "flag": "-spread",
+      "type": "number",
+      "description": "displace image pixels by a random amount",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "statistic",
+      "flag": "-statistic",
+      "type": "string",
+      "description": "replace each pixel with corresponding statistic from the neighborhood",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "strip",
+      "flag": "-strip",
+      "type": "boolean",
+      "description": "strip image of all profiles and comments",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "swirl",
+      "flag": "-swirl",
+      "type": "number",
+      "description": "swirl image pixels about the center",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "threshold",
+      "flag": "-threshold",
+      "type": "string",
+      "description": "threshold the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "thumbnail",
+      "flag": "-thumbnail",
+      "type": "string",
+      "description": "create a thumbnail of the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "tile",
+      "flag": "-tile",
+      "type": "path",
+      "description": "tile image when filling a graphic primitive",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "tint",
+      "flag": "-tint",
+      "type": "string",
+      "description": "tint the image with the fill color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "transform",
+      "flag": "-transform",
+      "type": "boolean",
+      "description": "affine transform image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "transparent",
+      "flag": "-transparent",
+      "type": "string",
+      "description": "make this color transparent within the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "transpose",
+      "flag": "-transpose",
+      "type": "boolean",
+      "description": "flip image vertically and rotate 90 degrees",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "transverse",
+      "flag": "-transverse",
+      "type": "boolean",
+      "description": "flop image horizontally and rotate 270 degrees",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "trim",
+      "flag": "-trim",
+      "type": "boolean",
+      "description": "trim image edges",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "type",
+      "flag": "-type",
+      "type": "string",
+      "description": "image type",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "unique-colors",
+      "flag": "-unique-colors",
+      "type": "boolean",
+      "description": "discard all but one of any pixel color",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "unsharp",
+      "flag": "-unsharp",
+      "type": "string",
+      "description": "sharpen the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "vignette",
+      "flag": "-vignette",
+      "type": "string",
+      "description": "soften the edges of the image in vignette style",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "wave",
+      "flag": "-wave",
+      "type": "string",
+      "description": "alter an image along a sine wave",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "wavelet-denoise",
+      "flag": "-wavelet-denoise",
+      "type": "string",
+      "description": "removes noise from the image using a wavelet transform",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "white-balance",
+      "flag": "-white-balance",
+      "type": "boolean",
+      "description": "automagically adjust white balance of image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "white-threshold",
+      "flag": "-white-threshold",
+      "type": "string",
+      "description": "force all pixels above the threshold into white",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Operators"
+    },
+    {
+      "name": "channel-fx",
+      "flag": "-channel-fx",
+      "type": "string",
+      "description": "exchange, extract, or transfer one or more image channels",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Channel Operators"
+    },
+    {
+      "name": "separate",
+      "flag": "-separate",
+      "type": "boolean",
+      "description": "separate an image channel into a grayscale image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Channel Operators"
+    },
+    {
+      "name": "append",
+      "flag": "-append",
+      "type": "boolean",
+      "description": "append an image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "clut",
+      "flag": "-clut",
+      "type": "boolean",
+      "description": "apply a color lookup table to the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "coalesce",
+      "flag": "-coalesce",
+      "type": "boolean",
+      "description": "merge a sequence of images",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "combine",
+      "flag": "-combine",
+      "type": "boolean",
+      "description": "combine a sequence of images",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "compare",
+      "flag": "-compare",
+      "type": "boolean",
+      "description": "mathematically and visually annotate the difference between an image and its reconstruction",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "complex",
+      "flag": "-complex",
+      "type": "string",
+      "description": "perform complex mathematics on an image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "composite",
+      "flag": "-composite",
+      "type": "boolean",
+      "description": "composite image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "copy",
+      "flag": "-copy",
+      "type": "string",
+      "description": "copy pixels from one area of an image to another",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "crop",
+      "flag": "-crop",
+      "type": "string",
+      "description": "cut out a rectangular region of the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "deconstruct",
+      "flag": "-deconstruct",
+      "type": "boolean",
+      "description": "break down an image sequence into constituent parts",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "evaluate-sequence",
+      "flag": "-evaluate-sequence",
+      "type": "string",
+      "description": "evaluate an arithmetic, relational, or logical expression",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "flatten",
+      "flag": "-flatten",
+      "type": "boolean",
+      "description": "flatten a sequence of images",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "fx",
+      "flag": "-fx",
+      "type": "string",
+      "description": "apply mathematical expression to an image channel(s)",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "hald-clut",
+      "flag": "-hald-clut",
+      "type": "boolean",
+      "description": "apply a Hald color lookup table to the image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "layers",
+      "flag": "-layers",
+      "type": "string",
+      "description": "optimize, merge, or compare image layers",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "morph",
+      "flag": "-morph",
+      "type": "number",
+      "description": "morph an image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "mosaic",
+      "flag": "-mosaic",
+      "type": "boolean",
+      "description": "create a mosaic from an image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "poly",
+      "flag": "-poly",
+      "type": "string",
+      "description": "build a polynomial from the image sequence and the corresponding terms",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "print",
+      "flag": "-print",
+      "type": "string",
+      "description": "interpret string and print to console",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "process",
+      "flag": "-process",
+      "type": "string",
+      "description": "process the image with a custom image filter",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "smush",
+      "flag": "-smush",
+      "type": "string",
+      "description": "smush an image sequence together",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "write",
+      "flag": "-write",
+      "type": "path",
+      "description": "write images to this file",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Sequence Operators"
+    },
+    {
+      "name": "clone",
+      "flag": "-clone",
+      "type": "string",
+      "description": "clone an image",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Stack Operators"
+    },
+    {
+      "name": "delete",
+      "flag": "-delete",
+      "type": "string",
+      "description": "delete the image from the image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Stack Operators"
+    },
+    {
+      "name": "duplicate",
+      "flag": "-duplicate",
+      "type": "string",
+      "description": "duplicate an image one or more times",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Stack Operators"
+    },
+    {
+      "name": "insert",
+      "flag": "-insert",
+      "type": "number",
+      "description": "insert last image into the image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Stack Operators"
+    },
+    {
+      "name": "reverse",
+      "flag": "-reverse",
+      "type": "boolean",
+      "description": "reverse image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Stack Operators"
+    },
+    {
+      "name": "swap",
+      "flag": "-swap",
+      "type": "string",
+      "description": "swap two images in the image sequence",
+      "enumValues": [],
+      "required": false,
+      "group": "Image Stack Operators"
+    },
+    {
+      "name": "debug",
+      "flag": "-debug",
+      "type": "string",
+      "description": "display copious debugging information",
+      "enumValues": [],
+      "required": false,
+      "group": "Miscellaneous Options"
+    },
+    {
+      "name": "distribute-cache",
+      "flag": "-distribute-cache",
+      "type": "number",
+      "description": "distributed pixel cache spanning one or more servers",
+      "enumValues": [],
+      "required": false,
+      "group": "Miscellaneous Options"
+    },
+    {
+      "name": "help",
+      "flag": "-help",
+      "type": "boolean",
+      "description": "print program options",
+      "enumValues": [],
+      "required": false,
+      "group": "Miscellaneous Options"
+    },
+    {
+      "name": "list",
+      "flag": "-list",
+      "type": "string",
+      "description": "print a list of supported option arguments",
+      "enumValues": [],
+      "required": false,
+      "group": "Miscellaneous Options"
+    },
+    {
+      "name": "log",
+      "flag": "-log",
+      "type": "string",
+      "description": "format of debugging information",
+      "enumValues": [],
+      "required": false,
+      "group": "Miscellaneous Options"
+    },
+    {
+      "name": "usage",
+      "flag": "-usage",
+      "type": "boolean",
+      "description": "print program usage",
+      "enumValues": [],
+      "required": false,
+      "group": "Miscellaneous Options"
+    },
+    {
+      "name": "version",
+      "flag": "-version",
+      "type": "boolean",
+      "description": "print version information",
+      "enumValues": [],
+      "required": false,
+      "group": "Miscellaneous Options"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "input_image",
+      "type": "path",
+      "description": "One or more input image files",
+      "required": false,
+      "variadic": true
+    },
+    {
+      "name": "output_image",
+      "type": "path",
+      "description": "Output image file",
+      "required": true,
+      "variadic": false
+    }
+  ]
+}

--- a/schemas/tar.json
+++ b/schemas/tar.json
@@ -1,0 +1,1450 @@
+{
+  "tool": "tar",
+  "summary": "GNU tar saves many files together into a single tape or disk archive, and can restore individual files from the archive.",
+  "options": [
+    {
+      "name": "catenate",
+      "flag": "-A, --catenate, --concatenate",
+      "type": "boolean",
+      "description": "Append tar files to an archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "create",
+      "flag": "-c, --create",
+      "type": "boolean",
+      "description": "Create a new archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "delete",
+      "flag": "--delete",
+      "type": "boolean",
+      "description": "Delete from the archive (not on mag tapes!)",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "diff",
+      "flag": "-d, --diff, --compare",
+      "type": "boolean",
+      "description": "Find differences between archive and file system",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "append",
+      "flag": "-r, --append",
+      "type": "boolean",
+      "description": "Append files to the end of an archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "test-label",
+      "flag": "--test-label",
+      "type": "boolean",
+      "description": "Test the archive volume label and exit",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "list",
+      "flag": "-t, --list",
+      "type": "boolean",
+      "description": "List the contents of an archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "update",
+      "flag": "-u, --update",
+      "type": "boolean",
+      "description": "Only append files newer than copy in archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "extract",
+      "flag": "-x, --extract, --get",
+      "type": "boolean",
+      "description": "Extract files from an archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Main operation mode"
+    },
+    {
+      "name": "check-device",
+      "flag": "--check-device",
+      "type": "boolean",
+      "description": "Check device numbers when creating incremental archives (default)",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "listed-incremental",
+      "flag": "-g, --listed-incremental=FILE",
+      "type": "path",
+      "description": "Handle new GNU-format incremental backup",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "incremental",
+      "flag": "-G, --incremental",
+      "type": "boolean",
+      "description": "Handle old GNU-format incremental backup",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "hole-detection",
+      "flag": "--hole-detection=TYPE",
+      "type": "string",
+      "description": "Technique to detect holes",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "ignore-failed-read",
+      "flag": "--ignore-failed-read",
+      "type": "boolean",
+      "description": "Do not exit with nonzero on unreadable files",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "level",
+      "flag": "--level=NUMBER",
+      "type": "number",
+      "description": "Dump level for created listed-incremental archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "no-check-device",
+      "flag": "--no-check-device",
+      "type": "boolean",
+      "description": "Do not check device numbers when creating incremental archives",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "no-seek",
+      "flag": "--no-seek",
+      "type": "boolean",
+      "description": "Archive is not seekable",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "seek",
+      "flag": "-n, --seek",
+      "type": "boolean",
+      "description": "Archive is seekable",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "occurrence",
+      "flag": "--occurrence[=NUMBER]",
+      "type": "string",
+      "description": "Process only the NUMBERth occurrence of each file in the archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "sparse-version",
+      "flag": "--sparse-version=MAJOR[.MINOR]",
+      "type": "string",
+      "description": "Set version of the sparse format to use (implies --sparse)",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "sparse",
+      "flag": "-S, --sparse",
+      "type": "boolean",
+      "description": "Handle sparse files efficiently",
+      "enumValues": [],
+      "required": false,
+      "group": "Operation modifiers"
+    },
+    {
+      "name": "add-file",
+      "flag": "--add-file=FILE",
+      "type": "path",
+      "description": "Add given FILE to the archive (useful if its name starts with a dash)",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "directory",
+      "flag": "-C, --directory=DIR",
+      "type": "path",
+      "description": "Change to directory DIR",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude",
+      "flag": "--exclude=PATTERN",
+      "type": "string",
+      "description": "Exclude files, given as a PATTERN",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-backups",
+      "flag": "--exclude-backups",
+      "type": "boolean",
+      "description": "Exclude backup and lock files",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-caches",
+      "flag": "--exclude-caches",
+      "type": "boolean",
+      "description": "Exclude contents of directories containing CACHEDIR.TAG, except for the tag file itself",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-caches-all",
+      "flag": "--exclude-caches-all",
+      "type": "boolean",
+      "description": "Exclude directories containing CACHEDIR.TAG",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-caches-under",
+      "flag": "--exclude-caches-under",
+      "type": "boolean",
+      "description": "Exclude everything under directories containing CACHEDIR.TAG",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-ignore",
+      "flag": "--exclude-ignore=FILE",
+      "type": "path",
+      "description": "Read exclude patterns for each directory from FILE, if it exists",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-ignore-recursive",
+      "flag": "--exclude-ignore-recursive=FILE",
+      "type": "path",
+      "description": "Read exclude patterns for each directory and its subdirectories from FILE, if it exists",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-tag",
+      "flag": "--exclude-tag=FILE",
+      "type": "path",
+      "description": "Exclude contents of directories containing FILE, except for FILE itself",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-tag-all",
+      "flag": "--exclude-tag-all=FILE",
+      "type": "path",
+      "description": "Exclude directories containing FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-tag-under",
+      "flag": "--exclude-tag-under=FILE",
+      "type": "path",
+      "description": "Exclude everything under directories containing FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-vcs",
+      "flag": "--exclude-vcs",
+      "type": "boolean",
+      "description": "Exclude version control system directories",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-vcs-ignores",
+      "flag": "--exclude-vcs-ignores",
+      "type": "boolean",
+      "description": "Read exclude patterns from the VCS ignore files",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "no-null",
+      "flag": "--no-null",
+      "type": "boolean",
+      "description": "Disable the effect of the previous --null option",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "no-recursion",
+      "flag": "--no-recursion",
+      "type": "boolean",
+      "description": "Avoid descending automatically in directories",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "no-unquote",
+      "flag": "--no-unquote",
+      "type": "boolean",
+      "description": "Do not unquote input file or member names",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "no-verbatim-files-from",
+      "flag": "--no-verbatim-files-from",
+      "type": "boolean",
+      "description": "-T treats file names starting with dash as options (default)",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "null",
+      "flag": "--null",
+      "type": "boolean",
+      "description": "-T reads null-terminated names; implies --verbatim-files-from",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "recursion",
+      "flag": "--recursion",
+      "type": "boolean",
+      "description": "Recurse into directories (default)",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "files-from",
+      "flag": "-T, --files-from=FILE",
+      "type": "path",
+      "description": "Get names to extract or create from FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "unquote",
+      "flag": "--unquote",
+      "type": "boolean",
+      "description": "Unquote input file or member names (default)",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "verbatim-files-from",
+      "flag": "--verbatim-files-from",
+      "type": "boolean",
+      "description": "-T reads file names verbatim (no escape or option handling)",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "exclude-from",
+      "flag": "-X, --exclude-from=FILE",
+      "type": "path",
+      "description": "Exclude patterns listed in FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file name selection"
+    },
+    {
+      "name": "anchored",
+      "flag": "--anchored",
+      "type": "boolean",
+      "description": "Patterns match file name start",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "ignore-case",
+      "flag": "--ignore-case",
+      "type": "boolean",
+      "description": "Ignore case",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "no-anchored",
+      "flag": "--no-anchored",
+      "type": "boolean",
+      "description": "Patterns match after any '/' (default for exclusion)",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "no-ignore-case",
+      "flag": "--no-ignore-case",
+      "type": "boolean",
+      "description": "Case sensitive matching (default)",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "no-wildcards",
+      "flag": "--no-wildcards",
+      "type": "boolean",
+      "description": "Verbatim string matching",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "no-wildcards-match-slash",
+      "flag": "--no-wildcards-match-slash",
+      "type": "boolean",
+      "description": "Wildcards do not match '/'",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "wildcards",
+      "flag": "--wildcards",
+      "type": "boolean",
+      "description": "Use wildcards (default for exclusion)",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "wildcards-match-slash",
+      "flag": "--wildcards-match-slash",
+      "type": "boolean",
+      "description": "Wildcards match '/' (default for exclusion)",
+      "enumValues": [],
+      "required": false,
+      "group": "File name matching options"
+    },
+    {
+      "name": "keep-directory-symlink",
+      "flag": "--keep-directory-symlink",
+      "type": "boolean",
+      "description": "Preserve existing symlinks to directories when extracting",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "keep-newer-files",
+      "flag": "--keep-newer-files",
+      "type": "boolean",
+      "description": "Don't replace existing files that are newer than their archive copies",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "keep-old-files",
+      "flag": "-k, --keep-old-files",
+      "type": "boolean",
+      "description": "Don't replace existing files when extracting, treat them as errors",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "no-overwrite-dir",
+      "flag": "--no-overwrite-dir",
+      "type": "boolean",
+      "description": "Preserve metadata of existing directories",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "one-top-level",
+      "flag": "--one-top-level[=DIR]",
+      "type": "string",
+      "description": "Create a subdirectory to avoid having loose files extracted",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "overwrite",
+      "flag": "--overwrite",
+      "type": "boolean",
+      "description": "Overwrite existing files when extracting",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "overwrite-dir",
+      "flag": "--overwrite-dir",
+      "type": "boolean",
+      "description": "Overwrite metadata of existing directories when extracting (default)",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "recursive-unlink",
+      "flag": "--recursive-unlink",
+      "type": "boolean",
+      "description": "Empty hierarchies prior to extracting directory",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "remove-files",
+      "flag": "--remove-files",
+      "type": "boolean",
+      "description": "Remove files after adding them to the archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "skip-old-files",
+      "flag": "--skip-old-files",
+      "type": "boolean",
+      "description": "Don't replace existing files when extracting, silently skip over them",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "unlink-first",
+      "flag": "-U, --unlink-first",
+      "type": "boolean",
+      "description": "Remove each file prior to extracting over it",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "verify",
+      "flag": "-W, --verify",
+      "type": "boolean",
+      "description": "Attempt to verify the archive after writing it",
+      "enumValues": [],
+      "required": false,
+      "group": "Overwrite control"
+    },
+    {
+      "name": "ignore-command-error",
+      "flag": "--ignore-command-error",
+      "type": "boolean",
+      "description": "Ignore exit codes of children",
+      "enumValues": [],
+      "required": false,
+      "group": "Select output stream"
+    },
+    {
+      "name": "no-ignore-command-error",
+      "flag": "--no-ignore-command-error",
+      "type": "boolean",
+      "description": "Treat non-zero exit codes of children as error",
+      "enumValues": [],
+      "required": false,
+      "group": "Select output stream"
+    },
+    {
+      "name": "to-stdout",
+      "flag": "-O, --to-stdout",
+      "type": "boolean",
+      "description": "Extract files to standard output",
+      "enumValues": [],
+      "required": false,
+      "group": "Select output stream"
+    },
+    {
+      "name": "to-command",
+      "flag": "--to-command=COMMAND",
+      "type": "string",
+      "description": "Pipe extracted files to another program",
+      "enumValues": [],
+      "required": false,
+      "group": "Select output stream"
+    },
+    {
+      "name": "atime-preserve",
+      "flag": "--atime-preserve[=METHOD]",
+      "type": "string",
+      "description": "Preserve access times on dumped files",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "clamp-mtime",
+      "flag": "--clamp-mtime",
+      "type": "boolean",
+      "description": "Only set time when the file is more recent than what was given with --mtime",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "delay-directory-restore",
+      "flag": "--delay-directory-restore",
+      "type": "boolean",
+      "description": "Delay setting modification times and permissions of extracted directories until the end of extraction",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "group",
+      "flag": "--group=NAME",
+      "type": "string",
+      "description": "Force NAME as group for added files",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "group-map",
+      "flag": "--group-map=FILE",
+      "type": "path",
+      "description": "Use FILE to map file owner GIDs and names",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "mode",
+      "flag": "--mode=CHANGES",
+      "type": "string",
+      "description": "Force (symbolic) mode CHANGES for added files",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "mtime",
+      "flag": "--mtime=DATE-OR-FILE",
+      "type": "string",
+      "description": "Set mtime for added files from DATE-OR-FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "touch",
+      "flag": "-m, --touch",
+      "type": "boolean",
+      "description": "Don't extract file modified time",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "no-delay-directory-restore",
+      "flag": "--no-delay-directory-restore",
+      "type": "boolean",
+      "description": "Cancel the effect of --delay-directory-restore option",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "no-same-owner",
+      "flag": "--no-same-owner",
+      "type": "boolean",
+      "description": "Extract files as yourself (default for ordinary users)",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "no-same-permissions",
+      "flag": "--no-same-permissions",
+      "type": "boolean",
+      "description": "Apply the user's umask when extracting permissions from the archive (default for ordinary users)",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "numeric-owner",
+      "flag": "--numeric-owner",
+      "type": "boolean",
+      "description": "Always use numbers for user/group names",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "owner",
+      "flag": "--owner=NAME",
+      "type": "string",
+      "description": "Force NAME as owner for added files",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "owner-map",
+      "flag": "--owner-map=FILE",
+      "type": "path",
+      "description": "Use FILE to map file owner UIDs and names",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "preserve-permissions",
+      "flag": "-p, --preserve-permissions, --same-permissions",
+      "type": "boolean",
+      "description": "Extract information about file permissions (default for superuser)",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "same-owner",
+      "flag": "--same-owner",
+      "type": "boolean",
+      "description": "Try extracting files with the same ownership as exists in the archive (default for superuser)",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "sort",
+      "flag": "--sort=ORDER",
+      "type": "enum",
+      "description": "Directory sorting order",
+      "enumValues": [
+        "none",
+        "name",
+        "inode"
+      ],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "preserve-order",
+      "flag": "-s, --preserve-order, --same-order",
+      "type": "boolean",
+      "description": "Member arguments are listed in the same order as the files in the archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of file attributes"
+    },
+    {
+      "name": "acls",
+      "flag": "--acls",
+      "type": "boolean",
+      "description": "Enable the POSIX ACLs support",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "no-acls",
+      "flag": "--no-acls",
+      "type": "boolean",
+      "description": "Disable the POSIX ACLs support",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "no-selinux",
+      "flag": "--no-selinux",
+      "type": "boolean",
+      "description": "Disable the SELinux context support",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "no-xattrs",
+      "flag": "--no-xattrs",
+      "type": "boolean",
+      "description": "Disable extended attributes support",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "selinux",
+      "flag": "--selinux",
+      "type": "boolean",
+      "description": "Enable the SELinux context support",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "xattrs",
+      "flag": "--xattrs",
+      "type": "boolean",
+      "description": "Enable extended attributes support",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "xattrs-exclude",
+      "flag": "--xattrs-exclude=MASK",
+      "type": "string",
+      "description": "Specify the exclude pattern for xattr keys",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "xattrs-include",
+      "flag": "--xattrs-include=MASK",
+      "type": "string",
+      "description": "Specify the include pattern for xattr keys",
+      "enumValues": [],
+      "required": false,
+      "group": "Handling of extended file attributes"
+    },
+    {
+      "name": "force-local",
+      "flag": "--force-local",
+      "type": "boolean",
+      "description": "Archive file is local even if it has a colon",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "file",
+      "flag": "-f, --file=ARCHIVE",
+      "type": "path",
+      "description": "Use archive file or device ARCHIVE",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "info-script",
+      "flag": "-F, --info-script=NAME, --new-volume-script=NAME",
+      "type": "string",
+      "description": "Run script at end of each tape (implies -M)",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "tape-length",
+      "flag": "-L, --tape-length=NUMBER",
+      "type": "number",
+      "description": "Change tape after writing NUMBER x 1024 bytes",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "multi-volume",
+      "flag": "-M, --multi-volume",
+      "type": "boolean",
+      "description": "Create/list/extract multi-volume archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "rmt-command",
+      "flag": "--rmt-command=COMMAND",
+      "type": "string",
+      "description": "Use given rmt COMMAND instead of rmt",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "rsh-command",
+      "flag": "--rsh-command=COMMAND",
+      "type": "string",
+      "description": "Use remote COMMAND instead of rsh",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "volno-file",
+      "flag": "--volno-file=FILE",
+      "type": "path",
+      "description": "Use/update the volume number in FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Device selection and switching"
+    },
+    {
+      "name": "blocking-factor",
+      "flag": "-b, --blocking-factor=BLOCKS",
+      "type": "number",
+      "description": "BLOCKS x 512 bytes per record",
+      "enumValues": [],
+      "required": false,
+      "group": "Device blocking"
+    },
+    {
+      "name": "read-full-records",
+      "flag": "-B, --read-full-records",
+      "type": "boolean",
+      "description": "Reblock as we read (for 4.2BSD pipes)",
+      "enumValues": [],
+      "required": false,
+      "group": "Device blocking"
+    },
+    {
+      "name": "ignore-zeros",
+      "flag": "-i, --ignore-zeros",
+      "type": "boolean",
+      "description": "Ignore zeroed blocks in archive (means EOF)",
+      "enumValues": [],
+      "required": false,
+      "group": "Device blocking"
+    },
+    {
+      "name": "record-size",
+      "flag": "--record-size=NUMBER",
+      "type": "number",
+      "description": "NUMBER of bytes per record, multiple of 512",
+      "enumValues": [],
+      "required": false,
+      "group": "Device blocking"
+    },
+    {
+      "name": "format",
+      "flag": "-H, --format=FORMAT",
+      "type": "enum",
+      "description": "Create archive of the given format",
+      "enumValues": [
+        "gnu",
+        "oldgnu",
+        "pax",
+        "posix",
+        "ustar",
+        "v7"
+      ],
+      "required": false,
+      "group": "Archive format selection"
+    },
+    {
+      "name": "old-archive",
+      "flag": "--old-archive, --portability",
+      "type": "boolean",
+      "description": "Same as --format=v7",
+      "enumValues": [],
+      "required": false,
+      "group": "Archive format selection"
+    },
+    {
+      "name": "pax-option",
+      "flag": "--pax-option=keyword[[:]=value][,keyword[[:]=value]]...",
+      "type": "string",
+      "description": "Control pax keywords",
+      "enumValues": [],
+      "required": false,
+      "group": "Archive format selection"
+    },
+    {
+      "name": "posix",
+      "flag": "--posix",
+      "type": "boolean",
+      "description": "Same as --format=posix",
+      "enumValues": [],
+      "required": false,
+      "group": "Archive format selection"
+    },
+    {
+      "name": "label",
+      "flag": "-V, --label=TEXT",
+      "type": "string",
+      "description": "Create archive with volume name TEXT; at list/extract time, use TEXT as a globbing pattern for volume name",
+      "enumValues": [],
+      "required": false,
+      "group": "Archive format selection"
+    },
+    {
+      "name": "auto-compress",
+      "flag": "-a, --auto-compress",
+      "type": "boolean",
+      "description": "Use archive suffix to determine the compression program",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "use-compress-program",
+      "flag": "-I, --use-compress-program=PROG",
+      "type": "string",
+      "description": "Filter through PROG (must accept -d)",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "bzip2",
+      "flag": "-j, --bzip2",
+      "type": "boolean",
+      "description": "Filter the archive through bzip2",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "xz",
+      "flag": "-J, --xz",
+      "type": "boolean",
+      "description": "Filter the archive through xz",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "lzip",
+      "flag": "--lzip",
+      "type": "boolean",
+      "description": "Filter the archive through lzip",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "lzma",
+      "flag": "--lzma",
+      "type": "boolean",
+      "description": "Filter the archive through lzma",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "lzop",
+      "flag": "--lzop",
+      "type": "boolean",
+      "description": "Filter the archive through lzop",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "no-auto-compress",
+      "flag": "--no-auto-compress",
+      "type": "boolean",
+      "description": "Do not use archive suffix to determine the compression program",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "zstd",
+      "flag": "--zstd",
+      "type": "boolean",
+      "description": "Filter the archive through zstd",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "gzip",
+      "flag": "-z, --gzip, --gunzip, --ungzip",
+      "type": "boolean",
+      "description": "Filter the archive through gzip",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "compress",
+      "flag": "-Z, --compress, --uncompress",
+      "type": "boolean",
+      "description": "Filter the archive through compress",
+      "enumValues": [],
+      "required": false,
+      "group": "Compression options"
+    },
+    {
+      "name": "backup",
+      "flag": "--backup[=CONTROL]",
+      "type": "string",
+      "description": "Backup before removal, choose version CONTROL",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "hard-dereference",
+      "flag": "--hard-dereference",
+      "type": "boolean",
+      "description": "Follow hard links; archive and dump the files they refer to",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "dereference",
+      "flag": "-h, --dereference",
+      "type": "boolean",
+      "description": "Follow symlinks; archive and dump the files they point to",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "starting-file",
+      "flag": "-K, --starting-file=MEMBER-NAME",
+      "type": "string",
+      "description": "Begin at member MEMBER-NAME when reading the archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "newer-mtime",
+      "flag": "--newer-mtime=DATE",
+      "type": "string",
+      "description": "Compare date and time when data changed only",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "newer",
+      "flag": "-N, --newer=DATE-OR-FILE, --after-date=DATE-OR-FILE",
+      "type": "string",
+      "description": "Only store files newer than DATE-OR-FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "one-file-system",
+      "flag": "--one-file-system",
+      "type": "boolean",
+      "description": "Stay in local file system when creating archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "absolute-names",
+      "flag": "-P, --absolute-names",
+      "type": "boolean",
+      "description": "Don't strip leading '/'s from file names",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "suffix",
+      "flag": "--suffix=STRING",
+      "type": "string",
+      "description": "Backup before removal, override usual suffix",
+      "enumValues": [],
+      "required": false,
+      "group": "Local file selection"
+    },
+    {
+      "name": "strip-components",
+      "flag": "--strip-components=NUMBER",
+      "type": "number",
+      "description": "Strip NUMBER leading components from file names on extraction",
+      "enumValues": [],
+      "required": false,
+      "group": "File name transformations"
+    },
+    {
+      "name": "transform",
+      "flag": "--transform=EXPRESSION, --xform=EXPRESSION",
+      "type": "string",
+      "description": "Use sed replace EXPRESSION to transform file names",
+      "enumValues": [],
+      "required": false,
+      "group": "File name transformations"
+    },
+    {
+      "name": "checkpoint",
+      "flag": "--checkpoint[=NUMBER]",
+      "type": "string",
+      "description": "Display progress messages every NUMBERth record (default 10)",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "checkpoint-action",
+      "flag": "--checkpoint-action=ACTION",
+      "type": "string",
+      "description": "Execute ACTION on each checkpoint",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "full-time",
+      "flag": "--full-time",
+      "type": "boolean",
+      "description": "Print file time to its full resolution",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "index-file",
+      "flag": "--index-file=FILE",
+      "type": "path",
+      "description": "Send verbose output to FILE",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "check-links",
+      "flag": "-l, --check-links",
+      "type": "boolean",
+      "description": "Print a message if not all links are dumped",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "no-quote-chars",
+      "flag": "--no-quote-chars=STRING",
+      "type": "string",
+      "description": "Disable quoting for characters from STRING",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "quote-chars",
+      "flag": "--quote-chars=STRING",
+      "type": "string",
+      "description": "Additionally quote characters from STRING",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "quoting-style",
+      "flag": "--quoting-style=STYLE",
+      "type": "enum",
+      "description": "Set name quoting style",
+      "enumValues": [
+        "literal",
+        "shell",
+        "shell-always",
+        "shell-escape",
+        "shell-escape-always",
+        "c",
+        "c-maybe",
+        "escape",
+        "locale",
+        "clocale"
+      ],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "block-number",
+      "flag": "-R, --block-number",
+      "type": "boolean",
+      "description": "Show block number within archive with each message",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "show-defaults",
+      "flag": "--show-defaults",
+      "type": "boolean",
+      "description": "Show tar defaults",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "show-omitted-dirs",
+      "flag": "--show-omitted-dirs",
+      "type": "boolean",
+      "description": "When listing or extracting, list each directory that does not match search criteria",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "show-snapshot-field-ranges",
+      "flag": "--show-snapshot-field-ranges",
+      "type": "boolean",
+      "description": "Show valid ranges for snapshot-file fields",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "show-transformed-names",
+      "flag": "--show-transformed-names, --show-stored-names",
+      "type": "boolean",
+      "description": "Show file or archive names after transformation",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "totals",
+      "flag": "--totals[=SIGNAL]",
+      "type": "string",
+      "description": "Print total bytes after processing the archive",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "utc",
+      "flag": "--utc",
+      "type": "boolean",
+      "description": "Print file modification times in UTC",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "verbose",
+      "flag": "-v, --verbose",
+      "type": "boolean",
+      "description": "Verbosely list files processed",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "warning",
+      "flag": "--warning=KEYWORD",
+      "type": "string",
+      "description": "Warning control",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "interactive",
+      "flag": "-w, --interactive, --confirmation",
+      "type": "boolean",
+      "description": "Ask for confirmation for every action",
+      "enumValues": [],
+      "required": false,
+      "group": "Informative output"
+    },
+    {
+      "name": "compat-o",
+      "flag": "-o",
+      "type": "boolean",
+      "description": "When creating, same as --old-archive; when extracting, same as --no-same-owner",
+      "enumValues": [],
+      "required": false,
+      "group": "Compatibility options"
+    },
+    {
+      "name": "help",
+      "flag": "-?, --help",
+      "type": "boolean",
+      "description": "Give this help list",
+      "enumValues": [],
+      "required": false,
+      "group": "Other options"
+    },
+    {
+      "name": "restrict",
+      "flag": "--restrict",
+      "type": "boolean",
+      "description": "Disable use of some potentially harmful options",
+      "enumValues": [],
+      "required": false,
+      "group": "Other options"
+    },
+    {
+      "name": "usage",
+      "flag": "--usage",
+      "type": "boolean",
+      "description": "Give a short usage message",
+      "enumValues": [],
+      "required": false,
+      "group": "Other options"
+    },
+    {
+      "name": "version",
+      "flag": "--version",
+      "type": "boolean",
+      "description": "Print program version",
+      "enumValues": [],
+      "required": false,
+      "group": "Other options"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "FILE",
+      "type": "path",
+      "description": "Files to add to or extract from the archive",
+      "required": false,
+      "variadic": true
+    }
+  ]
+}

--- a/schemas/zip.json
+++ b/schemas/zip.json
@@ -1,0 +1,310 @@
+{
+  "tool": "zip",
+  "summary": "Package and compress (archive) files into a ZIP file.",
+  "options": [
+    {
+      "name": "freshen",
+      "flag": "-f",
+      "type": "boolean",
+      "description": "Freshen: only changed files",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "update",
+      "flag": "-u",
+      "type": "boolean",
+      "description": "Update: only changed or new files",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "delete",
+      "flag": "-d",
+      "type": "boolean",
+      "description": "Delete entries in zipfile",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "move",
+      "flag": "-m",
+      "type": "boolean",
+      "description": "Move into zipfile (delete OS files)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "recurse",
+      "flag": "-r",
+      "type": "boolean",
+      "description": "Recurse into directories",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "junk-paths",
+      "flag": "-j",
+      "type": "boolean",
+      "description": "Junk (don't record) directory names",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "store-only",
+      "flag": "-0",
+      "type": "boolean",
+      "description": "Store only (no compression)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "convert-lf",
+      "flag": "-l",
+      "type": "boolean",
+      "description": "Convert LF to CR LF",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "compress-faster",
+      "flag": "-1",
+      "type": "boolean",
+      "description": "Compress faster",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "compress-better",
+      "flag": "-9",
+      "type": "boolean",
+      "description": "Compress better",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "quiet",
+      "flag": "-q",
+      "type": "boolean",
+      "description": "Quiet operation",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "verbose",
+      "flag": "-v",
+      "type": "boolean",
+      "description": "Verbose operation / print version info",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "comments",
+      "flag": "-c",
+      "type": "boolean",
+      "description": "Add one-line comments",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "zipfile-comment",
+      "flag": "-z",
+      "type": "boolean",
+      "description": "Add zipfile comment",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "read-stdin",
+      "flag": "-@",
+      "type": "boolean",
+      "description": "Read names from stdin",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "oldest",
+      "flag": "-o",
+      "type": "boolean",
+      "description": "Make zipfile as old as latest entry",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "exclude",
+      "flag": "-x",
+      "type": "string",
+      "description": "Exclude the following names",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "include",
+      "flag": "-i",
+      "type": "string",
+      "description": "Include only the following names",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "fix",
+      "flag": "-F",
+      "type": "boolean",
+      "description": "Fix zipfile (-FF try harder)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-dir-entries",
+      "flag": "-D",
+      "type": "boolean",
+      "description": "Do not add directory entries",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "adjust-sfx",
+      "flag": "-A",
+      "type": "boolean",
+      "description": "Adjust self-extracting exe",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "junk-sfx",
+      "flag": "-J",
+      "type": "boolean",
+      "description": "Junk zipfile prefix (unzipsfx)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "test",
+      "flag": "-T",
+      "type": "boolean",
+      "description": "Test zipfile integrity",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "exclude-extra",
+      "flag": "-X",
+      "type": "boolean",
+      "description": "eXclude eXtra file attributes",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "privileges",
+      "flag": "-!",
+      "type": "boolean",
+      "description": "Use privileges (if granted) to obtain all aspects of WinNT security",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "volume-label",
+      "flag": "-$",
+      "type": "boolean",
+      "description": "Include volume label",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "system-hidden",
+      "flag": "-S",
+      "type": "boolean",
+      "description": "Include system and hidden files",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "encrypt",
+      "flag": "-e",
+      "type": "boolean",
+      "description": "Encrypt",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "no-compress-suffixes",
+      "flag": "-n",
+      "type": "string",
+      "description": "Don't compress these suffixes",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "temp-path",
+      "flag": "-b",
+      "type": "path",
+      "description": "Use specified path for temporary files",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "before-date",
+      "flag": "-t",
+      "type": "string",
+      "description": "Only include files modified after specified date (mmddyyyy)",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    },
+    {
+      "name": "more-help",
+      "flag": "-h2",
+      "type": "boolean",
+      "description": "Show more help",
+      "enumValues": [],
+      "required": false,
+      "group": ""
+    }
+  ],
+  "positionals": [
+    {
+      "name": "zipfile",
+      "type": "path",
+      "description": "The ZIP archive file to create or modify",
+      "required": false,
+      "variadic": false
+    },
+    {
+      "name": "list",
+      "type": "string",
+      "description": "Files to add to the ZIP archive",
+      "required": false,
+      "variadic": true
+    }
+  ]
+}

--- a/scripts/gen-bundled-schemas.ts
+++ b/scripts/gen-bundled-schemas.ts
@@ -57,14 +57,68 @@ const DEMOS: Demo[] = [
       { flag: '-t', type: 'string' },
     ],
   },
+  // Growth item #1 — additional bundled tools (curl, jq, tar, magick, zip). rsync was
+  // requested too but has no clean Windows binary to capture an authentic --help fixture
+  // from, so it is deliberately not bundled (skip-with-a-note, never shipped broken).
+  {
+    tool: 'curl',
+    fixture: 'curl-help.txt',
+    golden: [
+      { flag: '-o', type: 'path' },
+      { flag: '-L', type: 'boolean' },
+      { flag: '-d', type: 'string' },
+    ],
+  },
+  {
+    tool: 'jq',
+    fixture: 'jq-help.txt',
+    golden: [
+      { flag: '-r', type: 'boolean' },
+      { flag: '-s', type: 'boolean' },
+      { flag: '-c', type: 'boolean' },
+    ],
+  },
+  {
+    tool: 'tar',
+    fixture: 'tar-help.txt',
+    golden: [
+      { flag: '-c', type: 'boolean' },
+      { flag: '-x', type: 'boolean' },
+      { flag: '-f', type: 'path' },
+    ],
+  },
+  {
+    tool: 'magick',
+    fixture: 'magick-help.txt',
+    golden: [
+      { flag: '-resize', type: 'string' },
+      { flag: '-quality', type: 'number' },
+      { flag: '-strip', type: 'boolean' },
+    ],
+  },
+  {
+    tool: 'zip',
+    fixture: 'zip-help.txt',
+    golden: [
+      { flag: '-r', type: 'boolean' },
+      { flag: '-e', type: 'boolean' },
+      { flag: '-m', type: 'boolean' },
+    ],
+  },
 ];
 
 async function main(): Promise<number> {
   mkdirSync(outDir, { recursive: true });
   console.error(`gen-bundled-schemas: engine=${activeEngineName()}`);
 
+  // Optional tool filter: `gen-bundled-schemas.ts curl jq` regenerates only those tools,
+  // leaving the other committed schemas untouched. No args → regenerate every bundled tool.
+  const only = new Set(process.argv.slice(2));
+  const selected = only.size > 0 ? DEMOS.filter((d) => only.has(d.tool)) : DEMOS;
+  if (only.size > 0) console.error(`gen-bundled-schemas: filter=${[...only].join(', ')}`);
+
   let failures = 0;
-  for (const demo of DEMOS) {
+  for (const demo of selected) {
     const helpText = readFileSync(path.join(fixtures, demo.fixture), 'utf8');
     console.error(`\n[${demo.tool}] extracting from ${demo.fixture} ...`);
     try {
@@ -98,7 +152,7 @@ async function main(): Promise<number> {
     }
   }
 
-  console.error(`\ngen-bundled-schemas: ${DEMOS.length - failures}/${DEMOS.length} generated.`);
+  console.error(`\ngen-bundled-schemas: ${selected.length - failures}/${selected.length} generated.`);
   return failures === 0 ? 0 : 1;
 }
 

--- a/test/bundled.test.ts
+++ b/test/bundled.test.ts
@@ -35,11 +35,20 @@ test('readBundled returns null for a tool that is not bundled', () => {
   }
 });
 
-// The keyless demo promise: these three must ship and resolve with no key, no API call.
+// The keyless promise: every bundled tool must ship and resolve with no key, no API call.
+// The first three are the original demo tools; the rest are growth item #1 (more bundled
+// tools). rsync was requested too but is deliberately not bundled — no clean binary exists to
+// capture an authentic --help fixture from, so it is skipped rather than shipped from a guessed
+// fixture. Each schema here is re-checked verbatim against its captured fixture.
 const DEMO_FIXTURES: Record<string, string> = {
   ffmpeg: 'ffmpeg-help.txt',
   'yt-dlp': 'yt-dlp-help.txt',
   pandoc: 'pandoc-help.txt',
+  curl: 'curl-help.txt',
+  jq: 'jq-help.txt',
+  tar: 'tar-help.txt',
+  magick: 'magick-help.txt',
+  zip: 'zip-help.txt',
 };
 
 for (const [tool, fixture] of Object.entries(DEMO_FIXTURES)) {

--- a/test/fixtures/curl-help.txt
+++ b/test/fixtures/curl-help.txt
@@ -1,0 +1,273 @@
+     --abstract-unix-socket <path>  Connect via abstract Unix domain socket
+     --alt-svc <filename>          Enable alt-svc with this cache file
+     --anyauth                     Pick any authentication method
+ -a, --append                      Append to target file when uploading
+     --aws-sigv4 <provider1[:prvdr2[:reg[:srv]]]>  AWS V4 signature auth
+     --basic                       HTTP Basic Authentication
+     --ca-native                   Load CA certs from the OS
+     --cacert <file>               CA certificate to verify peer against
+     --capath <dir>                CA directory to verify peer against
+ -E, --cert <certificate[:password]>  Client certificate file and password
+     --cert-status                 Verify server cert status OCSP-staple
+     --cert-type <type>            Certificate type (DER/PEM/ENG/PROV/P12)
+     --ciphers <list>              TLS 1.2 (1.1, 1.0) ciphers to use
+     --compressed                  Request compressed response
+     --compressed-ssh              Enable SSH compression
+ -K, --config <file>               Read config from a file
+     --connect-timeout <seconds>   Maximum time allowed to connect
+     --connect-to <HOST1:PORT1:HOST2:PORT2>  Connect to host2 instead of host1
+ -C, --continue-at <offset>        Resumed transfer offset
+ -b, --cookie <data|filename>      Send cookies from string/load from file
+ -c, --cookie-jar <filename>       Save cookies to <filename> after operation
+     --create-dirs                 Create necessary local directory hierarchy
+     --create-file-mode <mode>     File mode for created files
+     --crlf                        Convert LF to CRLF in upload
+     --crlfile <file>              Certificate Revocation list
+     --curves <list>               (EC) TLS key exchange algorithms to request
+ -d, --data <data>                 HTTP POST data
+     --data-ascii <data>           HTTP POST ASCII data
+     --data-binary <data>          HTTP POST binary data
+     --data-raw <data>             HTTP POST data, '@' allowed
+     --data-urlencode <data>       HTTP POST data URL encoded
+     --delegation <LEVEL>          GSS-API delegation permission
+     --digest                      HTTP Digest Authentication
+ -q, --disable                     Disable .curlrc
+     --disable-eprt                Inhibit using EPRT or LPRT
+     --disable-epsv                Inhibit using EPSV
+     --disallow-username-in-url    Disallow username in URL
+     --dns-interface <interface>   Interface to use for DNS requests
+     --dns-ipv4-addr <address>     IPv4 address to use for DNS requests
+     --dns-ipv6-addr <address>     IPv6 address to use for DNS requests
+     --dns-servers <addresses>     DNS server addrs to use
+     --doh-cert-status             Verify DoH server cert status OCSP-staple
+     --doh-insecure                Allow insecure DoH server connections
+     --doh-url <URL>               Resolve hostnames over DoH
+     --dump-ca-embed            Write the embedded CA bundle to standard output
+ -D, --dump-header <filename>      Write the received headers to <filename>
+     --ech <config>                Configure ECH
+     --egd-file <file>             EGD socket path for random data
+     --engine <name>               Crypto engine to use
+     --etag-compare <file>         Load ETag from file
+     --etag-save <file>            Parse incoming ETag and save to a file
+     --expect100-timeout <seconds>  How long to wait for 100-continue
+ -f, --fail                        Fail fast with no output on HTTP errors
+     --fail-early                  Fail on first transfer error
+     --fail-with-body              Fail on HTTP errors but save the body
+     --false-start                 Enable TLS False Start
+     --follow                      Follow redirects per spec
+ -F, --form <name=content>         Specify multipart MIME data
+     --form-escape                 Escape form fields using backslash
+     --form-string <name=string>   Specify multipart MIME data
+     --ftp-account <data>          Account data string
+     --ftp-alternative-to-user <command>  String to replace USER [name]
+     --ftp-create-dirs             Create the remote dirs if not present
+     --ftp-method <method>         Control CWD usage
+     --ftp-pasv                    Send PASV/EPSV instead of PORT
+ -P, --ftp-port <address>          Send PORT instead of PASV
+     --ftp-pret                    Send PRET before PASV
+     --ftp-skip-pasv-ip            Skip the IP address for PASV
+     --ftp-ssl-ccc                 Send CCC after authenticating
+     --ftp-ssl-ccc-mode <active/passive>  Set CCC mode
+     --ftp-ssl-control             Require TLS for login, clear for transfer
+ -G, --get                         Put the post data in the URL and use GET
+ -g, --globoff                     Disable URL globbing with {} and []
+     --happy-eyeballs-timeout-ms <ms>  Time for IPv6 before IPv4
+     --haproxy-clientip <ip>       Set address in HAProxy PROXY
+     --haproxy-protocol            Send HAProxy PROXY protocol v1 header
+ -I, --head                        Show document info only
+ -H, --header <header/@file>       Pass custom header(s) to server
+ -h, --help <subject>              Get help for commands
+     --hostpubmd5 <md5>            Acceptable MD5 hash of host public key
+     --hostpubsha256 <sha256>      Acceptable SHA256 hash of host public key
+     --hsts <filename>             Enable HSTS with this cache file
+     --http0.9                     Allow HTTP/0.9 responses
+ -0, --http1.0                     Use HTTP/1.0
+     --http1.1                     Use HTTP/1.1
+     --http2                       Use HTTP/2
+     --http2-prior-knowledge       Use HTTP/2 without HTTP/1.1 Upgrade
+     --http3                       Use HTTP/3
+     --http3-only                  Use HTTP/3 only
+     --ignore-content-length       Ignore the size of the remote resource
+ -k, --insecure                    Allow insecure server connections
+     --interface <name>            Use network interface
+     --ip-tos <string>             Set IP Type of Service or Traffic Class
+     --ipfs-gateway <URL>          Gateway for IPFS
+ -4, --ipv4                        Resolve names to IPv4 addresses
+ -6, --ipv6                        Resolve names to IPv6 addresses
+     --json <data>                 HTTP POST JSON
+ -j, --junk-session-cookies        Ignore session cookies read from file
+     --keepalive-cnt <integer>     Maximum number of keepalive probes
+     --keepalive-time <seconds>    Interval time for keepalive probes
+     --key <key>                   Private key filename
+     --key-type <type>             Private key file type (DER/PEM/ENG)
+     --knownhosts <file>           Specify knownhosts path
+     --krb <level>                 Enable Kerberos with security <level>
+     --libcurl <file>              Generate libcurl code for this command line
+     --limit-rate <speed>          Limit transfer speed to RATE
+ -l, --list-only                   List only mode
+     --local-port <range>          Use a local port number within RANGE
+ -L, --location                    Follow redirects
+     --location-trusted          As --location, but send secrets to other hosts
+     --login-options <options>     Server login options
+     --mail-auth <address>         Originator address of the original email
+     --mail-from <address>         Mail from this address
+     --mail-rcpt <address>         Mail to this address
+     --mail-rcpt-allowfails        Allow RCPT TO command to fail
+ -M, --manual                      Display the full manual
+     --max-filesize <bytes>        Maximum file size to download
+     --max-redirs <num>            Maximum number of redirects allowed
+ -m, --max-time <seconds>          Maximum time allowed for transfer
+     --metalink                    Process given URLs as metalink XML file
+     --mptcp                       Enable Multipath TCP
+     --negotiate                   Use HTTP Negotiate (SPNEGO) authentication
+ -n, --netrc                       Must read .netrc for username and password
+     --netrc-file <filename>       Specify FILE for netrc
+     --netrc-optional              Use either .netrc or URL
+ -:, --next                        Make next URL use separate options
+     --no-alpn                     Disable the ALPN TLS extension
+ -N, --no-buffer                   Disable buffering of the output stream
+     --no-clobber                  Do not overwrite files that already exist
+     --no-keepalive                Disable TCP keepalive on the connection
+     --no-npn                      Disable the NPN TLS extension
+     --no-progress-meter           Do not show the progress meter
+     --no-sessionid                Disable SSL session-ID reusing
+     --noproxy <no-proxy-list>     List of hosts which do not use proxy
+     --ntlm                        HTTP NTLM authentication
+     --ntlm-wb                     HTTP NTLM authentication with winbind
+     --oauth2-bearer <token>       OAuth 2 Bearer Token
+     --out-null                    Discard response data into the void
+ -o, --output <file>               Write to file instead of stdout
+     --output-dir <dir>            Directory to save files in
+ -Z, --parallel                    Perform transfers in parallel
+     --parallel-immediate          Do not wait for multiplexing
+     --parallel-max <num>          Maximum concurrency for parallel transfers
+     --parallel-max-host <num>     Maximum connections to a single host
+     --pass <phrase>               Passphrase for the private key
+     --path-as-is                  Do not squash .. sequences in URL path
+     --pinnedpubkey <hashes>       Public key to verify peer against
+     --post301                     Do not switch to GET after a 301 redirect
+     --post302                     Do not switch to GET after a 302 redirect
+     --post303                     Do not switch to GET after a 303 redirect
+     --preproxy <[protocol://]host[:port]>  Use this proxy first
+ -#, --progress-bar                Display transfer progress as a bar
+     --proto <protocols>           Enable/disable PROTOCOLS
+     --proto-default <protocol>    Use PROTOCOL for any URL missing a scheme
+     --proto-redir <protocols>     Enable/disable PROTOCOLS on redirect
+ -x, --proxy <[protocol://]host[:port]>  Use this proxy
+     --proxy-anyauth               Pick any proxy authentication method
+     --proxy-basic                 Use Basic authentication on the proxy
+     --proxy-ca-native             Load CA certs from the OS to verify proxy
+     --proxy-cacert <file>         CA certificates to verify proxy against
+     --proxy-capath <dir>          CA directory to verify proxy against
+     --proxy-cert <cert[:passwd]>  Set client certificate for proxy
+     --proxy-cert-type <type>      Client certificate type for HTTPS proxy
+     --proxy-ciphers <list>        TLS 1.2 (1.1, 1.0) ciphers to use for proxy
+     --proxy-crlfile <file>        Set a CRL list for proxy
+     --proxy-digest                Digest auth with the proxy
+     --proxy-header <header/@file>  Pass custom header(s) to proxy
+     --proxy-http2                 Use HTTP/2 with HTTPS proxy
+     --proxy-insecure              Skip HTTPS proxy cert verification
+     --proxy-key <key>             Private key for HTTPS proxy
+     --proxy-key-type <type>       Private key file type for proxy
+     --proxy-negotiate             HTTP Negotiate (SPNEGO) auth with the proxy
+     --proxy-ntlm                  NTLM authentication with the proxy
+     --proxy-pass <phrase>         Passphrase for private key for HTTPS proxy
+     --proxy-pinnedpubkey <hashes>  FILE/HASHES public key to verify proxy with
+     --proxy-service-name <name>   SPNEGO proxy service name
+     --proxy-ssl-allow-beast       Allow this security flaw for HTTPS proxy
+     --proxy-ssl-auto-client-cert  Auto client certificate for proxy
+     --proxy-tls13-ciphers <list>  TLS 1.3 proxy cipher suites
+     --proxy-tlsauthtype <type>    TLS authentication type for HTTPS proxy
+     --proxy-tlspassword <string>  TLS password for HTTPS proxy
+     --proxy-tlsuser <name>        TLS username for HTTPS proxy
+     --proxy-tlsv1                 TLSv1 for HTTPS proxy
+ -U, --proxy-user <user:password>  Proxy user and password
+     --proxy1.0 <host[:port]>      Use HTTP/1.0 proxy on given port
+ -p, --proxytunnel                 HTTP proxy tunnel (using CONNECT)
+     --pubkey <key>                SSH Public key filename
+ -Q, --quote <command>             Send command(s) to server before transfer
+     --random-file <file>          File for reading random data from
+ -r, --range <range>               Retrieve only the bytes within RANGE
+     --rate <max request rate>     Request rate for serial transfers
+     --raw                         Do HTTP raw; no transfer decoding
+ -e, --referer <URL>               Referrer URL
+ -J, --remote-header-name          Use the header-provided filename
+ -O, --remote-name                 Write output to file named as remote file
+     --remote-name-all             Use the remote filename for all URLs
+ -R, --remote-time                 Set remote file's time on local output
+     --remove-on-error             Remove output file on errors
+ -X, --request <method>            Specify request method to use
+     --request-target <path>       Specify the target for this request
+     --resolve <[+]host:port:addr[,addr]...>  Resolve host+port to address
+     --retry <num>                 Retry request if transient problems occur
+     --retry-all-errors            Retry all errors (with --retry)
+     --retry-connrefused           Retry on connection refused (with --retry)
+     --retry-delay <seconds>       Wait time between retries
+     --retry-max-time <seconds>    Retry only within this period
+     --sasl-authzid <identity>     Identity for SASL PLAIN authentication
+     --sasl-ir                     Initial response in SASL authentication
+     --service-name <name>         SPNEGO service name
+ -S, --show-error                  Show error even when -s is used
+ -i, --show-headers                Show response headers in output
+     --sigalgs <list>              TLS signature algorithms to use
+ -s, --silent                      Silent mode
+     --skip-existing               Skip download if local file already exists
+     --socks4 <host[:port]>        SOCKS4 proxy on given host + port
+     --socks4a <host[:port]>       SOCKS4a proxy on given host + port
+     --socks5 <host[:port]>        SOCKS5 proxy on given host + port
+     --socks5-basic                Username/password auth for SOCKS5 proxies
+     --socks5-gssapi               Enable GSS-API auth for SOCKS5 proxies
+     --socks5-gssapi-nec           Compatibility with NEC SOCKS5 server
+     --socks5-gssapi-service <name>  SOCKS5 proxy service name for GSS-API
+     --socks5-hostname <host[:port]>  SOCKS5 proxy, pass hostname to proxy
+ -Y, --speed-limit <speed>         Stop transfers slower than this
+ -y, --speed-time <seconds>        Trigger 'speed-limit' abort after this time
+     --ssl                         Try enabling TLS
+     --ssl-allow-beast             Allow security flaw to improve interop
+     --ssl-auto-client-cert        Use auto client certificate (Schannel)
+     --ssl-no-revoke               Disable cert revocation checks (Schannel)
+     --ssl-reqd                    Require SSL/TLS
+     --ssl-revoke-best-effort      Ignore missing cert CRL dist points
+     --ssl-sessions <filename>  Load/save SSL session tickets from/to this file
+ -2, --sslv2                       SSLv2
+ -3, --sslv3                       SSLv3
+     --stderr <file>               Where to redirect stderr
+     --styled-output               Enable styled output for HTTP headers
+     --suppress-connect-headers    Suppress proxy CONNECT response headers
+     --tcp-fastopen                Use TCP Fast Open
+     --tcp-nodelay                 Set TCP_NODELAY
+ -t, --telnet-option <opt=val>     Set telnet option
+     --tftp-blksize <value>        Set TFTP BLKSIZE option
+     --tftp-no-options             Do not send any TFTP options
+ -z, --time-cond <time>            Transfer based on a time condition
+     --tls-earlydata               Allow use of TLSv1.3 early data (0RTT)
+     --tls-max <VERSION>           Maximum allowed TLS version
+     --tls13-ciphers <list>        TLS 1.3 cipher suites to use
+     --tlsauthtype <type>          TLS authentication type
+     --tlspassword <string>        TLS password
+     --tlsuser <name>              TLS username
+ -1, --tlsv1                       TLSv1.0 or greater
+     --tlsv1.0                     TLSv1.0 or greater
+     --tlsv1.1                     TLSv1.1 or greater
+     --tlsv1.2                     TLSv1.2 or greater
+     --tlsv1.3                     TLSv1.3 or greater
+     --tr-encoding                 Request compressed transfer encoding
+     --trace <file>                Write a debug trace to FILE
+     --trace-ascii <file>          Like --trace, but without hex output
+     --trace-config <string>       Details to log in trace/verbose output
+     --trace-ids                   Transfer + connection ids in verbose output
+     --trace-time                  Add time stamps to trace/verbose output
+     --unix-socket <path>          Connect through this Unix domain socket
+ -T, --upload-file <file>          Transfer local FILE to destination
+     --upload-flags <flags>        IMAP upload behavior
+     --url <url/file>              URL(s) to work with
+     --url-query <data>            Add a URL query part
+ -B, --use-ascii                   Use ASCII/text transfer
+ -u, --user <user:password>        Server user and password
+ -A, --user-agent <name>           Send User-Agent <name> to server
+     --variable <[%]name=text/@file>  Set variable
+ -v, --verbose                     Make the operation more talkative
+ -V, --version                     Show version number and quit
+     --vlan-priority <priority>    Set VLAN priority
+ -w, --write-out <format>          Output FORMAT after completion
+     --xattr                       Store metadata in extended file attributes

--- a/test/fixtures/jq-help.txt
+++ b/test/fixtures/jq-help.txt
@@ -1,0 +1,63 @@
+jq - commandline JSON processor [version 1.8.2]
+
+Usage:	jq [options] <jq filter> [file...]
+	jq [options] --args <jq filter> [strings...]
+	jq [options] --jsonargs <jq filter> [JSON_TEXTS...]
+
+jq is a tool for processing JSON inputs, applying the given filter to
+its JSON text inputs and producing the filter's results as JSON on
+standard output.
+
+The simplest filter is ., which copies jq's input to its output
+unmodified except for formatting. For more advanced filters see
+the jq(1) manpage ("man jq") and/or https://jqlang.org/.
+
+Example:
+
+	$ echo '{"foo": 0}' | jq .
+	{
+	  "foo": 0
+	}
+
+Command options:
+  -n, --null-input          use `null` as the single input value;
+  -R, --raw-input           read each line as string instead of JSON;
+  -s, --slurp               read all inputs into an array and use it as
+                            the single input value;
+  -c, --compact-output      compact instead of pretty-printed output;
+  -r, --raw-output          output strings without escapes and quotes;
+      --raw-output0         implies -r and output NUL after each output;
+  -j, --join-output         implies -r and output without newline after
+                            each output;
+  -a, --ascii-output        output strings by only ASCII characters
+                            using escape sequences;
+  -S, --sort-keys           sort keys of each object on output;
+  -C, --color-output        colorize JSON output;
+  -M, --monochrome-output   disable colored output;
+      --tab                 use tabs for indentation;
+      --indent n            use n spaces for indentation (max 7 spaces);
+      --unbuffered          flush output stream after each output;
+      --stream              parse the input value in streaming fashion;
+      --stream-errors       implies --stream and report parse error as
+                            an array;
+      --seq                 parse input/output as application/json-seq;
+  -f, --from-file           load the filter from a file;
+  -L, --library-path dir    search modules from the directory;
+      --arg name value      set $name to the string value;
+      --argjson name value  set $name to the JSON value;
+      --slurpfile name file set $name to an array of JSON values read
+                            from the file;
+      --rawfile name file   set $name to string contents of file;
+      --args                consume remaining arguments as positional
+                            string values;
+      --jsonargs            consume remaining arguments as positional
+                            JSON values;
+  -e, --exit-status         set exit status code based on the output;
+  -b, --binary              open input/output streams in binary mode;
+  -V, --version             show the version;
+  --build-configuration     show jq's build configuration;
+  -h, --help                show the help;
+  --                        terminates argument processing;
+
+Named arguments are also available as $ARGS.named[], while
+positional arguments are available as $ARGS.positional[].

--- a/test/fixtures/magick-help.txt
+++ b/test/fixtures/magick-help.txt
@@ -1,0 +1,347 @@
+Version: ImageMagick 7.1.2-27 Q16-HDRI x64 b661ac9:20260705 https://imagemagick.org
+Copyright: (C) 1999 ImageMagick Studio LLC
+License: https://imagemagick.org/license/
+Features: Channel-masks(64-bit) Cipher DPC HDRI Modules OpenCL OpenMP(2.0) 
+Delegates (built-in): bzlib cairo freetype gslib heic jng jp2 jpeg jxl lcms lqr lzma openexr pangocairo png ps raqm raw rsvg tiff webp xml zip zlib
+Compiler: Visual Studio 2026 (195136248)
+Usage: magick.exe tool [ {option} | {image} ... ] {output_image}
+Usage: magick.exe [ {option} | {image} ... ] {output_image}
+       magick.exe [ {option} | {image} ... ] -script {filename} [ {script_args} ...]
+
+Image Settings:
+  -adjoin              join images into a single multi-image file
+  -affine matrix       affine transform matrix
+  -alpha option        activate, deactivate, reset, or set the alpha channel
+  -antialias           remove pixel-aliasing
+  -authenticate password
+                       decipher image with this password
+  -attenuate value     lessen (or intensify) when adding noise to an image
+  -background color    background color
+  -bias value          add bias when convolving an image
+  -black-point-compensation
+                       use black point compensation
+  -blue-primary point  chromaticity blue primary point
+  -bordercolor color   border color
+  -caption string      assign a caption to an image
+  -clip                clip along the first path from the 8BIM profile
+  -clip-mask filename  associate a clip mask with the image
+  -clip-path id        clip along a named path from the 8BIM profile
+  -colorspace type     alternate image colorspace
+  -comment string      annotate image with comment
+  -compose operator    set image composite operator
+  -compress type       type of pixel compression when writing the image
+  -define format:option
+                       define one or more image format options
+  -delay value         display the next image after pausing
+  -density geometry    horizontal and vertical density of the image
+  -depth value         image depth
+  -direction type      render text right-to-left or left-to-right
+  -display server      get image or font from this X server
+  -dispose method      layer disposal method
+  -dither method       apply error diffusion to image
+  -encoding type       text encoding type
+  -endian type         endianness (MSB or LSB) of the image
+  -family name         render text with this font family
+  -features distance   analyze image features (e.g. contrast, correlation)
+  -fill color          color to use when filling a graphic primitive
+  -filter type         use this filter when resizing an image
+  -font name           render text with this font
+  -format "string"     output formatted image characteristics
+  -fuzz distance       colors within this distance are considered equal
+  -gravity type        horizontal and vertical text placement
+  -green-primary point chromaticity green primary point
+  -illuminant type     reference illuminant
+  -intensity method    method to generate an intensity value from a pixel
+  -intent type         type of rendering intent when managing the image color
+  -interlace type      type of image interlacing scheme
+  -interline-spacing value
+                       set the space between two text lines
+  -interpolate method  pixel color interpolation method
+  -interword-spacing value
+                       set the space between two words
+  -kerning value       set the space between two letters
+  -label string        assign a label to an image
+  -limit type value    pixel cache resource limit
+  -loop iterations     add Netscape loop extension to your GIF animation
+  -matte               store matte channel if the image has one
+  -mattecolor color    frame color
+  -moments             report image moments
+  -monitor             monitor progress
+  -orient type         image orientation
+  -page geometry       size and location of an image canvas (setting)
+  -ping                efficiently determine image attributes
+  -pointsize value     font point size
+  -precision value     maximum number of significant digits to print
+  -preview type        image preview type
+  -quality value       JPEG/MIFF/PNG compression level
+  -quiet               suppress all warning messages
+  -read-mask filename  associate a read mask with the image
+  -red-primary point   chromaticity red primary point
+  -regard-warnings     pay attention to warning messages
+  -remap filename      transform image colors to match this set of colors
+  -repage geometry     size and location of an image canvas
+  -respect-parentheses settings remain in effect until parenthesis boundary
+  -sampling-factor geometry
+                       horizontal and vertical sampling factor
+  -scene value         image scene number
+  -seed value          seed a new sequence of pseudo-random numbers
+  -size geometry       width and height of image
+  -stretch type        render text with this font stretch
+  -stroke color        graphic primitive stroke color
+  -strokewidth value   graphic primitive stroke width
+  -style type          render text with this font style
+  -support factor      resize support: > 1.0 is blurry, < 1.0 is sharp
+  -synchronize         synchronize image to storage device
+  -taint               declare the image as modified
+  -texture filename    name of texture to tile onto the image background
+  -tile-offset geometry
+                       tile offset
+  -treedepth value     color tree depth
+  -transparent-color color
+                       transparent color
+  -undercolor color    annotation bounding box color
+  -units type          the units of image resolution
+  -verbose             print detailed information about the image
+  -view                FlashPix viewing transforms
+  -virtual-pixel method
+                       virtual pixel access method
+  -weight type         render text with this font weight
+  -white-point point   chromaticity white point
+  -write-mask filename associate a write mask with the image  -word-break type     sets whether line breaks appear wherever the text would otherwise overflow
+
+Image Operators:
+  -adaptive-blur geometry
+                       adaptively blur pixels; decrease effect near edges
+  -adaptive-resize geometry
+                       adaptively resize image using 'mesh' interpolation
+  -adaptive-sharpen geometry
+                       adaptively sharpen pixels; increase effect near edges
+  -alpha option        on, activate, off, deactivate, set, opaque, copy
+                       transparent, extract, background, or shape
+  -annotate geometry text
+                       annotate the image with text
+  -auto-gamma          automagically adjust gamma level of image
+  -auto-level          automagically adjust color levels of image
+  -auto-orient         automagically orient (rotate) image
+  -auto-threshold method
+                       automatically perform image thresholding
+  -bench iterations    measure performance
+  -bilateral-blur geometry
+                       non-linear, edge-preserving, and noise-reducing smoothing filter
+  -black-threshold value
+                       force all pixels below the threshold into black
+  -blue-shift factor   simulate a scene at nighttime in the moonlight
+  -blur geometry       reduce image noise and reduce detail levels
+  -border geometry     surround image with a border of color
+  -bordercolor color   border color
+  -brightness-contrast geometry
+                       improve brightness / contrast of the image
+  -canny geometry      detect edges in the image
+  -cdl filename        color correct with a color decision list
+  -channel mask        set the image channel mask
+  -charcoal radius     simulate a charcoal drawing
+  -chop geometry       remove pixels from the image interior
+  -clahe geometry      contrast limited adaptive histogram equalization
+  -clamp               keep pixel values in range (0-QuantumRange)
+  -colorize value      colorize the image with the fill color
+  -color-matrix matrix apply color correction to the image
+  -colors value        preferred number of colors in the image
+  -connected-components connectivity
+                       connected-components uniquely labeled
+  -contrast            enhance or reduce the image contrast
+  -contrast-stretch geometry
+                       improve contrast by 'stretching' the intensity range
+  -convolve coefficients
+                       apply a convolution kernel to the image
+  -cycle amount        cycle the image colormap
+  -decipher filename   convert cipher pixels to plain pixels
+  -deskew threshold    straighten an image
+  -despeckle           reduce the speckles within an image
+  -distort method args
+                       distort images according to given method and args
+  -draw string         annotate the image with a graphic primitive
+  -edge radius         apply a filter to detect edges in the image
+  -encipher filename   convert plain pixels to cipher pixels
+  -emboss radius       emboss an image
+  -enhance             apply a digital filter to enhance a noisy image
+  -equalize            perform histogram equalization to an image
+  -evaluate operator value
+                       evaluate an arithmetic, relational, or logical expression
+  -extent geometry     set the image size
+  -extract geometry    extract area from image
+  -fft                 implements the discrete Fourier transform (DFT)
+  -flip                flip image vertically
+  -floodfill geometry color
+                       floodfill the image with color
+  -flop                flop image horizontally
+  -frame geometry      surround image with an ornamental border
+  -function name parameters
+                       apply function over image values
+  -gamma value         level of gamma correction
+  -gaussian-blur geometry
+                       reduce image noise and reduce detail levels
+  -geometry geometry   preferred size or location of the image
+  -grayscale method    convert image to grayscale
+  -hough-lines geometry
+                       identify lines in the image
+  -identify            identify the format and characteristics of the image
+  -ift                 implements the inverse discrete Fourier transform (DFT)
+  -implode amount      implode image pixels about the center
+  -integral            calculate the sum of values (pixel values) in the image
+  -interpolative-resize geometry
+                       resize image using interpolation
+  -kmeans geometry     K means color reduction
+  -kuwahara geometry   edge preserving noise reduction filter
+  -lat geometry        local adaptive thresholding
+  -level value         adjust the level of image contrast
+  -level-colors color,color
+                       level image with the given colors
+  -linear-stretch geometry
+                       improve contrast by 'stretching with saturation'
+  -liquid-rescale geometry
+                       rescale image with seam-carving
+  -local-contrast geometry
+                       enhance local contrast
+  -mean-shift geometry delineate arbitrarily shaped clusters in the image
+  -median geometry     apply a median filter to the image
+  -mode geometry       make each pixel the 'predominant color' of the
+                       neighborhood
+  -modulate value      vary the brightness, saturation, and hue
+  -monochrome          transform image to black and white
+  -morphology method kernel
+                       apply a morphology method to the image
+  -motion-blur geometry
+                       simulate motion blur
+  -negate              replace every pixel with its complementary color 
+  -noise geometry      add or reduce noise in an image
+  -normalize           transform image to span the full range of colors
+  -opaque color        change this color to the fill color
+  -ordered-dither NxN
+                       add a noise pattern to the image with specific
+                       amplitudes
+  -paint radius        simulate an oil painting
+  -perceptible epsilon
+                       pixel value less than |epsilon| become epsilon or
+                       -epsilon
+  -polaroid angle      simulate a Polaroid picture
+  -posterize levels    reduce the image to a limited number of color levels
+  -profile filename    add, delete, or apply an image profile
+  -quantize colorspace reduce colors in this colorspace
+  -raise value         lighten/darken image edges to create a 3-D effect
+  -random-threshold low,high
+                       random threshold the image
+  -range-threshold values
+                       perform either hard or soft thresholding within some range of values in an image
+  -region geometry     apply options to a portion of the image
+  -render              render vector graphics
+  -resample geometry   change the resolution of an image
+  -reshape geometry    reshape the image
+  -resize geometry     resize the image
+  -roll geometry       roll an image vertically or horizontally
+  -rotate degrees      apply Paeth rotation to the image
+  -rotational-blur angle
+                       rotational blur the image
+  -sample geometry     scale image with pixel sampling
+  -scale geometry      scale the image
+  -segment values      segment an image
+  -selective-blur geometry
+                       selectively blur pixels within a contrast threshold
+  -sepia-tone threshold
+                       simulate a sepia-toned photo
+  -set property value  set an image property
+  -shade degrees       shade the image using a distant light source
+  -shadow geometry     simulate an image shadow
+  -sharpen geometry    sharpen the image
+  -shave geometry      shave pixels from the image edges
+  -shear geometry      slide one edge of the image along the X or Y axis
+  -sigmoidal-contrast geometry
+                       increase the contrast without saturating highlights or
+                       shadows
+  -sketch geometry     simulate a pencil sketch
+  -solarize threshold  negate all pixels above the threshold level
+  -sort-pixels         sort each scanline in ascending order of intensity
+  -sparse-color method args
+                       fill in a image based on a few color points
+  -splice geometry     splice the background color into the image
+  -spread radius       displace image pixels by a random amount
+  -statistic type geometry
+                       replace each pixel with corresponding statistic from the
+                       neighborhood
+  -strip               strip image of all profiles and comments
+  -swirl degrees       swirl image pixels about the center
+  -threshold value     threshold the image
+  -thumbnail geometry  create a thumbnail of the image
+  -tile filename       tile image when filling a graphic primitive
+  -tint value          tint the image with the fill color
+  -transform           affine transform image
+  -transparent color   make this color transparent within the image
+  -transpose           flip image vertically and rotate 90 degrees
+  -transverse          flop image horizontally and rotate 270 degrees
+  -trim                trim image edges
+  -type type           image type
+  -unique-colors       discard all but one of any pixel color
+  -unsharp geometry    sharpen the image
+  -vignette geometry   soften the edges of the image in vignette style
+  -wave geometry       alter an image along a sine wave
+  -wavelet-denoise threshold
+                       removes noise from the image using a wavelet transform
+  -white-balance       automagically adjust white balance of image
+  -white-threshold value
+                       force all pixels above the threshold into white
+
+Image Channel Operators:
+  -channel-fx expression
+                       exchange, extract, or transfer one or more image channels
+  -separate            separate an image channel into a grayscale image
+
+Image Sequence Operators:
+  -append              append an image sequence
+  -clut                apply a color lookup table to the image
+  -coalesce            merge a sequence of images
+  -combine             combine a sequence of images
+  -compare             mathematically and visually annotate the difference between an image and its reconstruction
+  -complex operator    perform complex mathematics on an image sequence
+  -composite           composite image
+  -copy geometry offset
+                       copy pixels from one area of an image to another
+  -crop geometry       cut out a rectangular region of the image
+  -deconstruct         break down an image sequence into constituent parts
+  -evaluate-sequence operator
+                       evaluate an arithmetic, relational, or logical expression
+  -flatten             flatten a sequence of images
+  -fx expression       apply mathematical expression to an image channel(s)
+  -hald-clut           apply a Hald color lookup table to the image
+  -layers method       optimize, merge, or compare image layers
+  -morph value         morph an image sequence
+  -mosaic              create a mosaic from an image sequence
+  -poly terms          build a polynomial from the image sequence and the corresponding
+                       terms (coefficients and degree pairs).
+  -print string        interpret string and print to console
+  -process arguments   process the image with a custom image filter
+  -smush geometry      smush an image sequence together
+  -write filename      write images to this file
+
+Image Stack Operators:
+  -clone indexes       clone an image
+  -delete indexes      delete the image from the image sequence
+  -duplicate count,indexes
+                       duplicate an image one or more times
+  -insert index        insert last image into the image sequence
+  -reverse             reverse image sequence
+  -swap indexes        swap two images in the image sequence
+
+Miscellaneous Options:
+  -debug events        display copious debugging information
+  -distribute-cache port
+                       distributed pixel cache spanning one or more servers
+  -help                print program options
+  -list type           print a list of supported option arguments
+  -log format          format of debugging information
+  -usage               print program usage
+  -version             print version information
+
+By default, the image format of 'file' is determined by its magic
+number.  To specify a particular image format, precede the filename
+with an image format name and a colon (i.e. ps:image) or specify the
+image type as the filename suffix (i.e. image.ps).  Specify 'file' as
+'-' for standard input or output.

--- a/test/fixtures/tar-help.txt
+++ b/test/fixtures/tar-help.txt
@@ -1,0 +1,325 @@
+Usage: tar [OPTION...] [FILE]...
+GNU 'tar' saves many files together into a single tape or disk archive, and can
+restore individual files from the archive.
+
+Examples:
+  tar -cf archive.tar foo bar  # Create archive.tar from files foo and bar.
+  tar -tvf archive.tar         # List all files in archive.tar verbosely.
+  tar -xf archive.tar          # Extract all files from archive.tar.
+
+ Main operation mode:
+  -A, --catenate, --concatenate   append tar files to an archive
+  -c, --create               create a new archive
+      --delete               delete from the archive (not on mag tapes!)
+  -d, --diff, --compare      find differences between archive and file system
+  -r, --append               append files to the end of an archive
+      --test-label           test the archive volume label and exit
+  -t, --list                 list the contents of an archive
+  -u, --update               only append files newer than copy in archive
+  -x, --extract, --get       extract files from an archive
+
+ Operation modifiers:
+
+      --check-device         check device numbers when creating incremental
+                             archives (default)
+  -g, --listed-incremental=FILE   handle new GNU-format incremental backup
+  -G, --incremental          handle old GNU-format incremental backup
+      --hole-detection=TYPE  technique to detect holes
+      --ignore-failed-read   do not exit with nonzero on unreadable files
+      --level=NUMBER         dump level for created listed-incremental archive
+      --no-check-device      do not check device numbers when creating
+                             incremental archives
+      --no-seek              archive is not seekable
+  -n, --seek                 archive is seekable
+      --occurrence[=NUMBER]  process only the NUMBERth occurrence of each file
+                             in the archive; this option is valid only in
+                             conjunction with one of the subcommands --delete,
+                             --diff, --extract or --list and when a list of
+                             files is given either on the command line or via
+                             the -T option; NUMBER defaults to 1
+      --sparse-version=MAJOR[.MINOR]
+                             set version of the sparse format to use (implies
+                             --sparse)
+  -S, --sparse               handle sparse files efficiently
+
+ Local file name selection:
+      --add-file=FILE        add given FILE to the archive (useful if its name
+                             starts with a dash)
+  -C, --directory=DIR        change to directory DIR
+      --exclude=PATTERN      exclude files, given as a PATTERN
+      --exclude-backups      exclude backup and lock files
+      --exclude-caches       exclude contents of directories containing
+                             CACHEDIR.TAG, except for the tag file itself
+      --exclude-caches-all   exclude directories containing CACHEDIR.TAG
+      --exclude-caches-under exclude everything under directories containing
+                             CACHEDIR.TAG
+      --exclude-ignore=FILE  read exclude patterns for each directory from
+                             FILE, if it exists
+      --exclude-ignore-recursive=FILE
+                             read exclude patterns for each directory and its
+                             subdirectories from FILE, if it exists
+      --exclude-tag=FILE     exclude contents of directories containing FILE,
+                             except for FILE itself
+      --exclude-tag-all=FILE exclude directories containing FILE
+      --exclude-tag-under=FILE   exclude everything under directories
+                             containing FILE
+      --exclude-vcs          exclude version control system directories
+      --exclude-vcs-ignores  read exclude patterns from the VCS ignore files
+      --no-null              disable the effect of the previous --null option
+      --no-recursion         avoid descending automatically in directories
+      --no-unquote           do not unquote input file or member names
+      --no-verbatim-files-from   -T treats file names starting with dash as
+                             options (default)
+      --null                 -T reads null-terminated names; implies
+                             --verbatim-files-from
+      --recursion            recurse into directories (default)
+  -T, --files-from=FILE      get names to extract or create from FILE
+      --unquote              unquote input file or member names (default)
+      --verbatim-files-from  -T reads file names verbatim (no escape or option
+                             handling)
+  -X, --exclude-from=FILE    exclude patterns listed in FILE
+
+ File name matching options (affect both exclude and include patterns):
+
+      --anchored             patterns match file name start
+      --ignore-case          ignore case
+      --no-anchored          patterns match after any '/' (default for
+                             exclusion)
+      --no-ignore-case       case sensitive matching (default)
+      --no-wildcards         verbatim string matching
+      --no-wildcards-match-slash   wildcards do not match '/'
+      --wildcards            use wildcards (default for exclusion)
+      --wildcards-match-slash   wildcards match '/' (default for exclusion)
+
+ Overwrite control:
+
+      --keep-directory-symlink   preserve existing symlinks to directories when
+                             extracting
+      --keep-newer-files     don't replace existing files that are newer than
+                             their archive copies
+  -k, --keep-old-files       don't replace existing files when extracting,
+                             treat them as errors
+      --no-overwrite-dir     preserve metadata of existing directories
+      --one-top-level[=DIR]  create a subdirectory to avoid having loose files
+                             extracted
+      --overwrite            overwrite existing files when extracting
+      --overwrite-dir        overwrite metadata of existing directories when
+                             extracting (default)
+      --recursive-unlink     empty hierarchies prior to extracting directory
+      --remove-files         remove files after adding them to the archive
+      --skip-old-files       don't replace existing files when extracting,
+                             silently skip over them
+  -U, --unlink-first         remove each file prior to extracting over it
+  -W, --verify               attempt to verify the archive after writing it
+
+ Select output stream:
+
+      --ignore-command-error ignore exit codes of children
+      --no-ignore-command-error   treat non-zero exit codes of children as
+                             error
+  -O, --to-stdout            extract files to standard output
+      --to-command=COMMAND   pipe extracted files to another program
+
+ Handling of file attributes:
+
+      --atime-preserve[=METHOD]   preserve access times on dumped files, either
+                             by restoring the times after reading
+                             (METHOD='replace'; default) or by not setting the
+                             times in the first place (METHOD='system')
+      --clamp-mtime          only set time when the file is more recent than
+                             what was given with --mtime
+      --delay-directory-restore   delay setting modification times and
+                             permissions of extracted directories until the end
+                             of extraction
+      --group=NAME           force NAME as group for added files
+      --group-map=FILE       use FILE to map file owner GIDs and names
+      --mode=CHANGES         force (symbolic) mode CHANGES for added files
+      --mtime=DATE-OR-FILE   set mtime for added files from DATE-OR-FILE
+  -m, --touch                don't extract file modified time
+      --no-delay-directory-restore
+                             cancel the effect of --delay-directory-restore
+                             option
+      --no-same-owner        extract files as yourself (default for ordinary
+                             users)
+      --no-same-permissions  apply the user's umask when extracting permissions
+                             from the archive (default for ordinary users)
+      --numeric-owner        always use numbers for user/group names
+      --owner=NAME           force NAME as owner for added files
+      --owner-map=FILE       use FILE to map file owner UIDs and names
+  -p, --preserve-permissions, --same-permissions
+                             extract information about file permissions
+                             (default for superuser)
+      --same-owner           try extracting files with the same ownership as
+                             exists in the archive (default for superuser)
+      --sort=ORDER           directory sorting order: none (default), name or
+                             inode
+  -s, --preserve-order, --same-order
+                             member arguments are listed in the same order as
+                             the files in the archive
+
+ Handling of extended file attributes:
+
+      --acls                 Enable the POSIX ACLs support
+      --no-acls              Disable the POSIX ACLs support
+      --no-selinux           Disable the SELinux context support
+      --no-xattrs            Disable extended attributes support
+      --selinux              Enable the SELinux context support
+      --xattrs               Enable extended attributes support
+      --xattrs-exclude=MASK  specify the exclude pattern for xattr keys
+      --xattrs-include=MASK  specify the include pattern for xattr keys
+
+ Device selection and switching:
+
+      --force-local          archive file is local even if it has a colon
+  -f, --file=ARCHIVE         use archive file or device ARCHIVE
+  -F, --info-script=NAME, --new-volume-script=NAME
+                             run script at end of each tape (implies -M)
+  -L, --tape-length=NUMBER   change tape after writing NUMBER x 1024 bytes
+  -M, --multi-volume         create/list/extract multi-volume archive
+      --rmt-command=COMMAND  use given rmt COMMAND instead of rmt
+      --rsh-command=COMMAND  use remote COMMAND instead of rsh
+      --volno-file=FILE      use/update the volume number in FILE
+
+ Device blocking:
+
+  -b, --blocking-factor=BLOCKS   BLOCKS x 512 bytes per record
+  -B, --read-full-records    reblock as we read (for 4.2BSD pipes)
+  -i, --ignore-zeros         ignore zeroed blocks in archive (means EOF)
+      --record-size=NUMBER   NUMBER of bytes per record, multiple of 512
+
+ Archive format selection:
+
+  -H, --format=FORMAT        create archive of the given format
+
+ FORMAT is one of the following:
+    gnu                      GNU tar 1.13.x format
+    oldgnu                   GNU format as per tar <= 1.12
+    pax                      POSIX 1003.1-2001 (pax) format
+    posix                    same as pax
+    ustar                    POSIX 1003.1-1988 (ustar) format
+    v7                       old V7 tar format
+
+      --old-archive, --portability
+                             same as --format=v7
+      --pax-option=keyword[[:]=value][,keyword[[:]=value]]...
+                             control pax keywords
+      --posix                same as --format=posix
+  -V, --label=TEXT           create archive with volume name TEXT; at
+                             list/extract time, use TEXT as a globbing pattern
+                             for volume name
+
+ Compression options:
+
+  -a, --auto-compress        use archive suffix to determine the compression
+                             program
+  -I, --use-compress-program=PROG
+                             filter through PROG (must accept -d)
+  -j, --bzip2                filter the archive through bzip2
+  -J, --xz                   filter the archive through xz
+      --lzip                 filter the archive through lzip
+      --lzma                 filter the archive through lzma
+      --lzop                 filter the archive through lzop
+      --no-auto-compress     do not use archive suffix to determine the
+                             compression program
+      --zstd                 filter the archive through zstd
+  -z, --gzip, --gunzip, --ungzip   filter the archive through gzip
+  -Z, --compress, --uncompress   filter the archive through compress
+
+ Local file selection:
+
+      --backup[=CONTROL]     backup before removal, choose version CONTROL
+      --hard-dereference     follow hard links; archive and dump the files they
+                             refer to
+  -h, --dereference          follow symlinks; archive and dump the files they
+                             point to
+  -K, --starting-file=MEMBER-NAME
+                             begin at member MEMBER-NAME when reading the
+                             archive
+      --newer-mtime=DATE     compare date and time when data changed only
+  -N, --newer=DATE-OR-FILE, --after-date=DATE-OR-FILE
+                             only store files newer than DATE-OR-FILE
+      --one-file-system      stay in local file system when creating archive
+  -P, --absolute-names       don't strip leading '/'s from file names
+      --suffix=STRING        backup before removal, override usual suffix ('~'
+                             unless overridden by environment variable
+                             SIMPLE_BACKUP_SUFFIX)
+
+ File name transformations:
+
+      --strip-components=NUMBER   strip NUMBER leading components from file
+                             names on extraction
+      --transform=EXPRESSION, --xform=EXPRESSION
+                             use sed replace EXPRESSION to transform file
+                             names
+
+ Informative output:
+
+      --checkpoint[=NUMBER]  display progress messages every NUMBERth record
+                             (default 10)
+      --checkpoint-action=ACTION   execute ACTION on each checkpoint
+      --full-time            print file time to its full resolution
+      --index-file=FILE      send verbose output to FILE
+  -l, --check-links          print a message if not all links are dumped
+      --no-quote-chars=STRING   disable quoting for characters from STRING
+      --quote-chars=STRING   additionally quote characters from STRING
+      --quoting-style=STYLE  set name quoting style; see below for valid STYLE
+                             values
+  -R, --block-number         show block number within archive with each message
+                            
+      --show-defaults        show tar defaults
+      --show-omitted-dirs    when listing or extracting, list each directory
+                             that does not match search criteria
+      --show-snapshot-field-ranges
+                             show valid ranges for snapshot-file fields
+      --show-transformed-names, --show-stored-names
+                             show file or archive names after transformation
+      --totals[=SIGNAL]      print total bytes after processing the archive;
+                             with an argument - print total bytes when this
+                             SIGNAL is delivered; Allowed signals are: SIGHUP,
+                             SIGQUIT, SIGINT, SIGUSR1 and SIGUSR2; the names
+                             without SIG prefix are also accepted
+      --utc                  print file modification times in UTC
+  -v, --verbose              verbosely list files processed
+      --warning=KEYWORD      warning control
+  -w, --interactive, --confirmation
+                             ask for confirmation for every action
+
+ Compatibility options:
+
+  -o                         when creating, same as --old-archive; when
+                             extracting, same as --no-same-owner
+
+ Other options:
+
+  -?, --help                 give this help list
+      --restrict             disable use of some potentially harmful options
+      --usage                give a short usage message
+      --version              print program version
+
+Mandatory or optional arguments to long options are also mandatory or optional
+for any corresponding short options.
+
+The backup suffix is '~', unless set with --suffix or SIMPLE_BACKUP_SUFFIX.
+The version control may be set with --backup or VERSION_CONTROL, values are:
+
+  none, off       never make backups
+  t, numbered     make numbered backups
+  nil, existing   numbered if numbered backups exist, simple otherwise
+  never, simple   always make simple backups
+
+Valid arguments for the --quoting-style option are:
+
+  literal
+  shell
+  shell-always
+  shell-escape
+  shell-escape-always
+  c
+  c-maybe
+  escape
+  locale
+  clocale
+
+*This* tar defaults to:
+--format=gnu -f- -b20 --quoting-style=escape --rmt-command=/usr/lib/tar/rmt.exe
+--rsh-command=/usr/bin/rsh

--- a/test/fixtures/zip-help.txt
+++ b/test/fixtures/zip-help.txt
@@ -1,0 +1,23 @@
+Copyright (c) 1990-2008 Info-ZIP - Type 'zip "-L"' for software license.
+Zip 3.0 (July 5th 2008). Usage:
+zip [-options] [-b path] [-t mmddyyyy] [-n suffixes] [zipfile list] [-xi list]
+  The default action is to add or replace zipfile entries from list, which
+  can include the special name - to compress standard input.
+  If zipfile and list are omitted, zip compresses stdin to stdout.
+  -f   freshen: only changed files  -u   update: only changed or new files
+  -d   delete entries in zipfile    -m   move into zipfile (delete OS files)
+  -r   recurse into directories     -j   junk (don't record) directory names
+  -0   store only                   -l   convert LF to CR LF (-ll CR LF to LF)
+  -1   compress faster              -9   compress better
+  -q   quiet operation              -v   verbose operation/print version info
+  -c   add one-line comments        -z   add zipfile comment
+  -@   read names from stdin        -o   make zipfile as old as latest entry
+  -x   exclude the following names  -i   include only the following names
+  -F   fix zipfile (-FF try harder) -D   do not add directory entries
+  -A   adjust self-extracting exe   -J   junk zipfile prefix (unzipsfx)
+  -T   test zipfile integrity       -X   eXclude eXtra file attributes
+  -!   use privileges (if granted) to obtain all aspects of WinNT security
+  -$   include volume label         -S   include system and hidden files
+  -e   encrypt                      -n   don't compress these suffixes
+  -h2  show more help
+  


### PR DESCRIPTION
## Summary

Sponsorship + growth work, bundled into one PR. Four commits, one per change:

1. **`chore(funding)`** — `.github/FUNDING.yml` (`github: Soutar97`) so the repo shows a Sponsor button.
2. **`docs(readme)`** — a short **Support** section above the license: sponsor on GitHub, star, contribute schemas. Direct voice, no guilt-tripping.
3. **`feat(schemas)`** — five more bundled keyless tools (growth item #1): **curl, jq, tar, magick, zip**.
4. **`docs(readme)`** — remove the obsolete `TODO(pre-launch)` demo-GIF marker.

## Bundled schemas — verification

Generated with the existing `scripts/gen-bundled-schemas.ts` pipeline; each schema passes the **hallucination guard** (every flag appears verbatim in its captured `--help` fixture) **and** a golden sanity floor. All eight shipped schemas are re-verified in `test/bundled.test.ts`.

| Tool | Options | Guard | Status |
| --- | --- | --- | --- |
| curl | 273 | ✅ pass | bundled |
| jq | 30 | ✅ pass | bundled |
| tar | 157 | ✅ pass | bundled |
| magick | 262 | ✅ pass | bundled |
| zip | 32 | ✅ pass | bundled |
| **rsync** | — | — | **skipped (see below)** |

**rsync was intentionally skipped, not shipped broken.** No clean binary was available to capture an authentic `--help` fixture from (not on winget; results are rclone/backup tools). A bundled schema is only as trustworthy as the fixture it was verified against, so rsync is skipped rather than generated from a guessed fixture. Noted in `schemas/README.md`.

Because curl/magick are now bundled (keyless), the README's stale "`npx instagui curl` needs a key" example and the "bundled = ffmpeg/yt-dlp/pandoc" enumerations were corrected to keep the docs consistent with what actually ships.

## Demo GIF verdict

**Renders on github.com.** `docs/demo.gif` is committed on `main`, valid `GIF89a`; the raw URL returns `HTTP 200`, `Content-Type: image/gif`, `1,343,110 bytes`, referenced by the correct relative path. The `TODO(pre-launch)` marker is removed.

## Checks

- `npm run build` ✅  ·  `npm run lint` ✅  ·  `npm test` → **156 pass / 0 fail / 4 skipped** (the 4 skips are the live-key tests that self-skip by design).

## Security / invariants

- Extraction ran keyless via the local `claude` engine. On Windows, Node refuses to `spawn` the `claude.cmd` shim under `shell:false` (EINVAL); this was resolved **without weakening the `shell:false` invariant** — by resolving the native `claude.exe` on PATH. No API key was read or written; no `.env`/secret files were touched. A throwaway `~/.instagui/config.json` used only to bump the extraction timeout was removed afterward.
- Zero new runtime dependencies.

## AI-assisted

The bundled schemas were AI-extracted (claude-code engine) and are gated by the hallucination + golden guards. Per `schemas/README.md`, the SDK/haiku pre-publish regeneration gate applies to these five as it does to the original three.
