### PR TITLE
chore(dependabot): group dev-dependency minor/patch bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,18 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    # Collapse routine dev-tooling noise: minor + patch bumps of
+    # devDependencies land in one weekly PR instead of one-per-package.
+    # Scope is deliberately narrow — production deps (@anthropic-ai/sdk,
+    # zod) and ALL major bumps stay ungrouped so each gets its own PR and
+    # its own review, per CLAUDE.md's runtime-dependency and supply-chain
+    # rules.
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
 
   # GitHub Actions used in workflows. Dependabot bumps the pinned commit SHAs
   # (and updates the version comment beside each) so pin-by-SHA stays current.


### PR DESCRIPTION
## What

Adds a `groups` section to the npm ecosystem entry in `.github/dependabot.yml` so **minor + patch bumps of devDependencies** are collapsed into **one weekly PR** instead of one PR per package.

```yaml
groups:
  dev-dependencies:
    dependency-type: development
    update-types:
      - minor
      - patch
```

## Why

Per-package PRs for routine dev-tooling bumps (`tsx`, `@types/node`, `typescript-eslint`, etc.) add review overhead with little signal. Grouping the low-risk minor/patch dev bumps keeps that to a single reviewable PR each week.

## Scope is deliberately narrow

- **Production deps** (`@anthropic-ai/sdk`, `zod`) are **not** grouped — `dependency-type: development` excludes them.
- **Major bumps** (any dependency) stay **ungrouped** and each gets its own PR/review.

This keeps individual review on the changes that carry real risk, consistent with CLAUDE.md's runtime-dependency and supply-chain rules.

## Notes
- No merge intended by the author — open for review.
- AI-assisted: config authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)