### PR TITLE
chore(dependabot): ignore typescript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,18 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # TypeScript major bumps are blocked by our lint toolchain, not our code:
+      # typescript-eslint 8.x pins `peer typescript >=4.8.4 <6.1.0`, and
+      # @typescript-eslint/typescript-estree crashes on TS 7's native-port
+      # compiler internals — failing npm ci, lint, and the AD-2 dependency-rule
+      # tests. TS 7 itself compiles our sources fine; the ecosystem just hasn't
+      # caught up. Stop the weekly re-open against the same wall (closed PR #13);
+      # revisit deliberately once typescript-eslint ships TS 7 support, then drop
+      # this ignore. Minor/patch TS updates still flow through normally.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
 
   # GitHub Actions used in workflows. Dependabot bumps the pinned commit SHAs
   # (and updates the version comment beside each) so pin-by-SHA stays current.


### PR DESCRIPTION
## What

Adds an `ignore` rule for `typescript` **semver-major** updates to the npm ecosystem entry in `.github/dependabot.yml`.

```yaml
ignore:
  - dependency-name: typescript
    update-types:
      - version-update:semver-major
```

## Why

TypeScript 7 (the native/Go port) is blocked by our **lint toolchain**, not our own code:

- `typescript-eslint@8.x` declares `peer typescript >=4.8.4 <6.1.0`.
- `@typescript-eslint/typescript-estree` crashes on TS 7's changed compiler internals (`TypeError: Cannot read properties of undefined (reading 'Cjs')`), which fails `npm ci`, `lint`, and the AD-2 dependency-rule tests.
- TS 7 itself compiles our sources cleanly — the ecosystem just hasn't caught up.

This was evaluated and closed in **#13**. Without an ignore rule, Dependabot re-opens the same unmergeable PR every week against the same wall.

## Scope

- **Majors only.** Minor/patch TypeScript updates still flow through normally.
- Remove this ignore once `typescript-eslint` ships TS 7 support, and revisit the upgrade deliberately.

## Notes
- No merge intended by the author — open for review.
- AI-assisted: config authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)