### PR TITLE
chore(ci): same-line pin comments so Dependabot updates them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,10 @@ jobs:
         node: [22]
     steps:
       - name: Checkout
-        # actions/checkout v7.0.0
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node ${{ matrix.node }}
-        # actions/setup-node v6.4.0
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout v7.0.0
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node 22
-        # actions/setup-node v6.4.0
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## What

Moves the `# actions/<name> vX.Y.Z` version annotations onto the **same line** as each pinned `uses: …@<sha>` in `ci.yml` and `release.yml`, and corrects the setup-node label to `v7.0.0`.

```diff
-        # actions/setup-node v6.4.0
-        uses: actions/setup-node@820762786...
+        uses: actions/setup-node@820762786... # v7.0.0
```

## Why

Dependabot only rewrites a pin's version comment when it's on the **same line** as `uses: …@<sha>`. With the comment on the line above, the setup-node v7 bump (#17) updated the SHA but left a **stale `v6.4.0` annotation above the v7 SHA** — the exact drift this fixes. Same-line comments are updated automatically on every future bump.

## Notes
- **No functional change** — SHAs and pinned versions are unchanged (setup-node stays on its already-merged v7.0.0 SHA); only comment placement plus correcting the setup-node label to match its SHA. Both files validated as YAML.
- Rebuilt on top of current `main` after #17 merged, so it no longer touches the SHA — earlier revision was branched pre-#17.
- No merge intended by the author — open for review.
- AI-assisted: authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)