### PR TITLE
chore(dependabot): ignore @types/node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,16 @@ updates:
       - dependency-name: typescript
         update-types:
           - version-update:semver-major
+      # @types/node must track our lowest supported runtime, not the latest
+      # release. `engines` pins node >=22 and CI runs a Node 22-only matrix, so
+      # 22 is the real floor. Types ahead of the floor (e.g. @types/node 26)
+      # invert the guardrail: the compiler would accept APIs added after Node 22
+      # that don't exist at runtime, failing only on a user's Node 22 — not at
+      # build time. Majors only; minor/patch @types/node updates flow normally.
+      # Drop this (and bump the pin) when `engines`/the CI matrix raise the floor.
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
 
   # GitHub Actions used in workflows. Dependabot bumps the pinned commit SHAs
   # (and updates the version comment beside each) so pin-by-SHA stays current.


### PR DESCRIPTION
## What

Adds an `ignore` rule for `@types/node` **semver-major** updates, mirroring the typescript-major rule from #21 (already on main).

```yaml
- dependency-name: "@types/node"
  update-types:
    - version-update:semver-major
```

## Why

`@types/node` should track our **lowest supported runtime**, not the latest release. `engines` pins `node >=22` and CI runs a **Node 22-only** matrix, so 22 is the real floor. Types ahead of the floor (e.g. `@types/node` 26, evaluated in **PR #20**) invert the compiler guardrail: TypeScript would accept APIs added after Node 22 that don't exist at runtime, failing only on a user's Node 22 rather than at build time.

This makes PR #20 (@types/node → 26.1.1) auto-close and stops the weekly re-open, the same way #21 handles TypeScript majors.

## Scope
- **Majors only.** Minor/patch `@types/node` updates still flow through normally.
- Drop this rule and bump the pin when `engines`/the CI matrix deliberately raise the Node floor.

## Notes
- Diff is a single `ignore` entry appended to the block #21 created; verified clean against `main` (no conflict).
- No merge intended by the author — open for review.
- AI-assisted: config authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)