### PR TITLE
chore(release): 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "instagui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "instagui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.111.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instagui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "npx instagui <any-cli-tool> — turn any CLI tool into a local web GUI. One command.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## What

Bumps the package version **0.2.0 → 0.2.1** — `package.json` + `package-lock.json` only. **No git tag** is created here (`npm version patch --no-git-tag-version`).

## How the release actually ships

Per `RELEASING.md`, tagging and `npm publish` are **not** done in this PR. After this merges:
1. Create a GitHub Release on the `v0.2.1` tag.
2. Publishing to npm happens automatically via the provenance workflow (`.github/workflows/release.yml`, OIDC Trusted Publishing, `--provenance`) when the Release is **published**.

This PR just lands the version bump on `main` so the Release can be cut from it.

## Contents of 0.2.1 (for the Release notes)
- GitHub Sponsors button (FUNDING.yml)
- Five new bundled keyless schemas: curl, jq, tar, magick, zip (now **eight** total)
- SSH `autossh` persistent-session docs
- Dependency refresh: zod 4, eslint 10, @anthropic-ai/sdk 0.111
- CI + provenance publishing + security infrastructure (matrix CI, Dependabot, SECURITY policy)

## Notes
- Diff is version strings only — no dependency or source changes.
- The release workflow's "refuse to republish an existing version" guard confirms 0.2.1 is not yet on npm.
- AI-assisted: authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)